### PR TITLE
feat: 공동 응답 객체

### DIFF
--- a/src/main/java/com/example/wini/global/response/ApiResponse.java
+++ b/src/main/java/com/example/wini/global/response/ApiResponse.java
@@ -1,19 +1,8 @@
 package com.example.wini.global.response;
 
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-@Getter
-public class ApiResponse<T> {
-
-  private final int status;
-  private final T data;
-
-  private ApiResponse(final int status, final T data) {
-    this.status = status;
-    this.data = data;
-  }
-
+public record ApiResponse<T>(int status, T data) {
   // 상태 코드 200 OK를 기본값으로 사용하는 성공 응답
   public static <T> ApiResponse<T> success(final T data) {
     return new ApiResponse<>(HttpStatus.OK.value(), data);

--- a/src/main/java/com/example/wini/global/response/ApiResponse.java
+++ b/src/main/java/com/example/wini/global/response/ApiResponse.java
@@ -1,6 +1,7 @@
 package com.example.wini.global.response;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class ApiResponse<T> {
@@ -15,12 +16,12 @@ public class ApiResponse<T> {
 
   // 상태 코드 200 OK를 기본값으로 사용하는 성공 응답
   public static <T> ApiResponse<T> success(final T data) {
-    return new ApiResponse<>(200, data);
+    return new ApiResponse<>(HttpStatus.OK.value(), data);
   }
 
   // 상태 코드 200 OK를 기본값으로 사용하는 성공 응답 (데이터 X)
   public static <T> ApiResponse<T> success() {
-    return new ApiResponse<>(200, null);
+    return new ApiResponse<>(HttpStatus.OK.value(), null);
   }
 
   // 데이터를 포함한 성공 응답

--- a/src/main/java/com/example/wini/global/response/ApiResponse.java
+++ b/src/main/java/com/example/wini/global/response/ApiResponse.java
@@ -1,0 +1,35 @@
+package com.example.wini.global.response;
+
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+  private final int status;
+  private final T data;
+
+  private ApiResponse(final int status, final T data) {
+    this.status = status;
+    this.data = data;
+  }
+
+  // 상태 코드 200 OK를 기본값으로 사용하는 성공 응답
+  public static <T> ApiResponse<T> success(final T data) {
+    return new ApiResponse<>(200, data);
+  }
+
+  // 상태 코드 200 OK를 기본값으로 사용하는 성공 응답 (데이터 X)
+  public static <T> ApiResponse<T> success() {
+    return new ApiResponse<>(200, null);
+  }
+
+  // 데이터를 포함한 성공 응답
+  public static <T> ApiResponse<T> success(final int status, final T data) {
+    return new ApiResponse<>(status, data);
+  }
+
+  // 데이터 없이 싱테 코드만 포함한 성공 응답
+  public static <T> ApiResponse<T> success(final int status) {
+    return new ApiResponse<>(status, null);
+  }
+}

--- a/src/main/java/com/example/wini/global/response/ApiResponse.java
+++ b/src/main/java/com/example/wini/global/response/ApiResponse.java
@@ -25,12 +25,12 @@ public class ApiResponse<T> {
   }
 
   // 데이터를 포함한 성공 응답
-  public static <T> ApiResponse<T> success(final int status, final T data) {
-    return new ApiResponse<>(status, data);
+  public static <T> ApiResponse<T> success(final HttpStatus status, final T data) {
+    return new ApiResponse<>(status.value(), data);
   }
 
   // 데이터 없이 싱테 코드만 포함한 성공 응답
-  public static <T> ApiResponse<T> success(final int status) {
-    return new ApiResponse<>(status, null);
+  public static <T> ApiResponse<T> success(final HttpStatus status) {
+    return new ApiResponse<>(status.value(), null);
   }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #27

## 📌 작업 내용 및 특이사항
- 클라이언트 개발 편의성을 위해 API 공동 응답 객체를 추가했습니다. 

## 📝 참고사항
- 4가지 형태로 나누어서 상황에 따라 맞는거 쓰시면 될 것 같습니다!
- 200 ok 사용 시에 응답 데이터가 없을 시에는 첫번째 사진처럼, 있을 시에는 두번째 사진처럼 사용하시면 됩니다.
<img width="778" height="174" alt="image" src="https://github.com/user-attachments/assets/8932300a-3f71-4ddb-bf07-e2a7c2cc5a61" />
<img width="882" height="194" alt="image" src="https://github.com/user-attachments/assets/87390e7c-d07c-4367-83a8-1232264fee49" />

- 응답 결과
<img width="934" height="406" alt="image" src="https://github.com/user-attachments/assets/b38a63f6-3b55-4606-be0b-3488f54d1428" />
<img width="364" height="186" alt="image" src="https://github.com/user-attachments/assets/de19354a-bbc1-4dc9-8f7a-fde4d86f3331" />


## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * API 응답을 단일한 일관된 포맷(status, data)으로 제공하여 클라이언트 처리 용이성 향상
  * 성공 응답을 간편히 생성하는 헬퍼 메서드 제공(기본값 200)
  * 사용자 지정 HTTP 상태 코드를 포함한 성공 응답 생성 지원
  * 데이터 유무와 관계없이 동일한 구조로 응답 반환으로 가독성/일관성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->