### PR TITLE
feat: 마음쪽지 상세 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // Database
+    runtimeOnly 'com.h2database:h2'
+
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 

--- a/src/main/java/com/example/wini/domain/note/controller/NoteController.java
+++ b/src/main/java/com/example/wini/domain/note/controller/NoteController.java
@@ -4,6 +4,7 @@ import com.example.wini.domain.note.dto.response.NoteResponse;
 import com.example.wini.domain.note.service.NoteService;
 import com.example.wini.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,8 +18,8 @@ public class NoteController {
   private final NoteService noteService;
 
   @GetMapping("/{noteId}")
-  public ApiResponse<NoteResponse> getNote(@PathVariable Long noteId) {
+  public ResponseEntity<ApiResponse<NoteResponse>> getNote(@PathVariable Long noteId) {
     NoteResponse response = noteService.findNoteById(noteId);
-    return ApiResponse.success(response);
+    return ResponseEntity.ok(ApiResponse.success(response));
   }
 }

--- a/src/main/java/com/example/wini/domain/note/controller/NoteController.java
+++ b/src/main/java/com/example/wini/domain/note/controller/NoteController.java
@@ -1,0 +1,24 @@
+package com.example.wini.domain.note.controller;
+
+import com.example.wini.domain.note.dto.response.NoteResponse;
+import com.example.wini.domain.note.service.NoteService;
+import com.example.wini.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/notes")
+@RequiredArgsConstructor
+public class NoteController {
+
+  private final NoteService noteService;
+
+  @GetMapping("/{noteId}")
+  public ApiResponse<NoteResponse> getNote(@PathVariable Long noteId) {
+    NoteResponse response = noteService.findNoteById(noteId);
+    return ApiResponse.success(response);
+  }
+}

--- a/src/main/java/com/example/wini/domain/note/domain/Note.java
+++ b/src/main/java/com/example/wini/domain/note/domain/Note.java
@@ -1,0 +1,91 @@
+package com.example.wini.domain.note.domain;
+
+import com.example.wini.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Note extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long memberRoomSenderId;
+
+  @Column(nullable = false)
+  private Long memberRoomReceiverId;
+
+  @Column(nullable = false)
+  private Long emotionId;
+
+  @Column(nullable = true)
+  private Long situationId;
+
+  @Column(nullable = false)
+  private Long actionId;
+
+  @Column(nullable = false)
+  private Long promiseId;
+
+  @Column(nullable = false)
+  private Long closingId;
+
+  @Column(nullable = false)
+  private int sequence;
+
+  @Column(nullable = false)
+  private boolean isRead;
+
+  @Column(nullable = false)
+  private boolean isSaved;
+
+  @Builder(access = AccessLevel.PRIVATE)
+  private Note(
+      Long memberRoomSenderId,
+      Long memberRoomReceiverId,
+      Long emotionId,
+      Long situationId,
+      Long actionId,
+      Long promiseId,
+      Long closingId,
+      int sequence) {
+    this.memberRoomSenderId = memberRoomSenderId;
+    this.memberRoomReceiverId = memberRoomReceiverId;
+    this.emotionId = emotionId;
+    this.situationId = situationId;
+    this.actionId = actionId;
+    this.promiseId = promiseId;
+    this.closingId = closingId;
+    this.sequence = sequence;
+    this.isRead = false;
+    this.isSaved = false;
+  }
+
+  public static Note create(
+      Long memberRoomSenderId,
+      Long memberRoomReceiverId,
+      Long emotionId,
+      Long situationId,
+      Long actionId,
+      Long promiseId,
+      Long closingId,
+      int sequence) {
+    return Note.builder()
+        .memberRoomSenderId(memberRoomSenderId)
+        .memberRoomReceiverId(memberRoomReceiverId)
+        .emotionId(emotionId)
+        .situationId(situationId)
+        .actionId(actionId)
+        .promiseId(promiseId)
+        .closingId(closingId)
+        .sequence(sequence)
+        .build();
+  }
+}

--- a/src/main/java/com/example/wini/domain/note/dto/response/NoteResponse.java
+++ b/src/main/java/com/example/wini/domain/note/dto/response/NoteResponse.java
@@ -1,0 +1,31 @@
+package com.example.wini.domain.note.dto.response;
+
+import com.example.wini.domain.note.domain.Note;
+
+public record NoteResponse(
+    Long id,
+    Long memberRoomSenderId,
+    Long memberRoomReceiverId,
+    Long emotionId,
+    Long situationId,
+    Long actionId,
+    Long promiseId,
+    Long closingId,
+    int sequence,
+    boolean isRead,
+    boolean isSaved) {
+  public static NoteResponse from(Note note) {
+    return new NoteResponse(
+        note.getId(),
+        note.getMemberRoomSenderId(),
+        note.getMemberRoomReceiverId(),
+        note.getEmotionId(),
+        note.getSituationId(),
+        note.getActionId(),
+        note.getPromiseId(),
+        note.getClosingId(),
+        note.getSequence(),
+        note.isRead(),
+        note.isSaved());
+  }
+}

--- a/src/main/java/com/example/wini/domain/note/repository/NoteRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteRepository.java
@@ -1,0 +1,6 @@
+package com.example.wini.domain.note.repository;
+
+import com.example.wini.domain.note.domain.Note;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoteRepository extends JpaRepository<Note, Long> {}

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -1,0 +1,28 @@
+package com.example.wini.domain.note.service;
+
+import static com.example.wini.global.error.exception.ErrorCode.*;
+
+import com.example.wini.domain.note.domain.Note;
+import com.example.wini.domain.note.dto.response.NoteResponse;
+import com.example.wini.domain.note.repository.NoteRepository;
+import com.example.wini.global.error.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NoteService {
+
+  private final NoteRepository noteRepository;
+
+  @Transactional(readOnly = true)
+  public NoteResponse findNoteById(Long noteId) {
+    Note note =
+        noteRepository.findById(noteId).orElseThrow(() -> new CustomException(NOTE_NOT_FOUND));
+
+    return NoteResponse.from(note);
+  }
+}

--- a/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
@@ -22,6 +22,9 @@ public enum ErrorCode {
 
   // Member
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+
+  // Note
+  NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 마음쪽지입니다."),
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,16 @@
+spring:
+  config:
+    activate:
+      on-profile: "dev"
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 30MB

--- a/src/main/resources/application-h2.yml
+++ b/src/main/resources/application-h2.yml
@@ -1,0 +1,15 @@
+spring:
+  config:
+    activate:
+      on-profile: "h2"
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+  h2:
+    console:
+      enabled: true
+      path: /h2-console

--- a/src/main/resources/application-swagger.yml
+++ b/src/main/resources/application-swagger.yml
@@ -1,3 +1,7 @@
+spring:
+  config:
+    activate:
+      on-profile: "swagger"
 springdoc:
   swagger-ui:
     persist-authorization: true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=wini

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,9 @@
 spring:
-  application:
-    name: wini
-
   profiles:
+    group:
+      dev: "dev, h2"
     include:
       - swagger
+
+  application:
+    name: wini


### PR DESCRIPTION
## 🌱 관련 이슈
- close #6

## 📌 작업 내용 및 특이사항
- 마음쪽지 도메인 생성
- 마음쪽지 상세 조회 API 구현
- H2 데이터베이스 연결
- `application.yml` 파일 분리

## 📝 참고사항
- JPA 연결을 위해 임시로 H2 데이터베이스를 연결했습니다.
- 마음쪽지 템플릿 도메인 생성 이후에 엔티티 연결 예정입니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 마음쪽지 상세 조회 엔드포인트 추가: ID로 마음쪽지 정보를 조회하고 상태(읽음/저장) 등 주요 필드를 반환합니다.
  - 미존재 마음쪽지 요청 시 404 상태와 명확한 오류 메시지를 제공하여 응답 일관성을 개선했습니다.
- 작업
  - 런타임 H2 데이터베이스 의존성을 추가해 로컬 실행/검증 환경을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->