### PR TITLE
feat: 저장된 마음쪽지 리스트 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,19 +14,6 @@ java {
     }
 }
 
-spotless {
-    java {
-        target("src/**/*.java")
-        targetExclude("**/build/**", "**/.gradle/**")
-        googleJavaFormat().reflowLongStrings()
-        importOrder()
-        removeUnusedImports()
-        trimTrailingWhitespace()
-        endWithNewline()
-        formatAnnotations()
-    }
-}
-
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
@@ -38,10 +25,10 @@ repositories {
 }
 
 dependencies {
-    // spring basic
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    // spring boot starters
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'
@@ -54,7 +41,35 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 
     // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+test {
+    useJUnitPlatform()
+}
+
+jar {
+    enabled = false
+}
+
+spotless {
+    java {
+        target("src/**/*.java")
+        targetExclude("**/build/**", "**/.gradle/**")
+        googleJavaFormat().reflowLongStrings()
+        importOrder()
+        removeUnusedImports()
+        trimTrailingWhitespace()
+        endWithNewline()
+        formatAnnotations()
+    }
 }
 
 tasks.register('autoInstallHooks') {

--- a/src/main/java/com/example/wini/domain/note/controller/NoteController.java
+++ b/src/main/java/com/example/wini/domain/note/controller/NoteController.java
@@ -3,6 +3,7 @@ package com.example.wini.domain.note.controller;
 import com.example.wini.domain.note.dto.response.NoteResponse;
 import com.example.wini.domain.note.service.NoteService;
 import com.example.wini.global.response.ApiResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,5 +22,11 @@ public class NoteController {
   public ResponseEntity<ApiResponse<NoteResponse>> getNote(@PathVariable Long noteId) {
     NoteResponse response = noteService.findNoteById(noteId);
     return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+  @GetMapping("/saved")
+  public ResponseEntity<ApiResponse<List<NoteResponse>>> getSavedNotes() {
+    List<NoteResponse> responses = noteService.findSavedNotes();
+    return ResponseEntity.ok(ApiResponse.success(responses));
   }
 }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
@@ -1,0 +1,8 @@
+package com.example.wini.domain.note.repository;
+
+import com.example.wini.domain.note.domain.Note;
+import java.util.List;
+
+public interface NoteCustomRepository {
+  List<Note> findSavedNotes();
+}

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.example.wini.domain.note.repository;
+
+import static com.example.wini.domain.note.domain.QNote.note;
+
+import com.example.wini.domain.note.domain.Note;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class NoteCustomRepositoryImpl implements NoteCustomRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Note> findSavedNotes() {
+    return queryFactory.selectFrom(note).where(note.isSaved.eq(true)).fetch();
+  }
+}

--- a/src/main/java/com/example/wini/domain/note/repository/NoteRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteRepository.java
@@ -3,4 +3,4 @@ package com.example.wini.domain.note.repository;
 import com.example.wini.domain.note.domain.Note;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NoteRepository extends JpaRepository<Note, Long> {}
+public interface NoteRepository extends JpaRepository<Note, Long>, NoteCustomRepository {}

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -6,6 +6,7 @@ import com.example.wini.domain.note.domain.Note;
 import com.example.wini.domain.note.dto.response.NoteResponse;
 import com.example.wini.domain.note.repository.NoteRepository;
 import com.example.wini.global.error.exception.CustomException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,7 +23,14 @@ public class NoteService {
   public NoteResponse findNoteById(Long noteId) {
     Note note =
         noteRepository.findById(noteId).orElseThrow(() -> new CustomException(NOTE_NOT_FOUND));
-
+    // TODO : 인가받은 사용자 확인 후 읽음 처리 필요
     return NoteResponse.from(note);
+  }
+
+  @Transactional(readOnly = true)
+  public List<NoteResponse> findSavedNotes() {
+    // TODO : 인가받은 사용자의 노트로 필터링 필요
+    List<Note> notes = noteRepository.findSavedNotes();
+    return notes.stream().map(NoteResponse::from).toList();
   }
 }

--- a/src/main/java/com/example/wini/global/config/QuerydslConfig.java
+++ b/src/main/java/com/example/wini/global/config/QuerydslConfig.java
@@ -1,0 +1,17 @@
+package com.example.wini.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+  @PersistenceContext private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #9

## 📌 작업 내용 및 특이사항
- Querydsl 설정
- 저장된 마음쪽지 리스트 조회 API 구현

## 📝 참고사항
- Querydsl 설정하는 과정에서 일부 태스크 및 의존성 순서 변경이 이우러졌습니다.
- 인가된 사용자에 맞게 필터링하는 기능은 추후에 구현할 예정입니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 저장한 노트 목록을 조회하는 GET API(/notes/saved) 추가. 저장된 노트를 리스트로 반환.
- 작업
  - 빌드 설정 정리 및 의존성 구성 개선: 데이터 접근/검증 모듈 추가, 테스트 실행 플랫폼 설정, JAR 생성 비활성화.
  - Querydsl 사용을 위한 기본 설정 추가.
- 테스트
  - JUnit Platform 기반으로 테스트 실행 환경 정비.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->