### PR TITLE
feat: 최근 받은 쪽지 리스트 조회

### DIFF
--- a/src/main/java/com/example/wini/domain/note/controller/NoteController.java
+++ b/src/main/java/com/example/wini/domain/note/controller/NoteController.java
@@ -24,6 +24,12 @@ public class NoteController {
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 
+  @GetMapping("/today")
+  public ResponseEntity<ApiResponse<List<NoteResponse>>> getTodayNotes() {
+    List<NoteResponse> responses = noteService.findTodayNotes();
+    return ResponseEntity.ok(ApiResponse.success(responses));
+  }
+
   @GetMapping("/saved")
   public ResponseEntity<ApiResponse<List<NoteResponse>>> getSavedNotes() {
     List<NoteResponse> responses = noteService.findSavedNotes();

--- a/src/main/java/com/example/wini/domain/note/controller/NoteController.java
+++ b/src/main/java/com/example/wini/domain/note/controller/NoteController.java
@@ -3,6 +3,8 @@ package com.example.wini.domain.note.controller;
 import com.example.wini.domain.note.dto.response.NoteResponse;
 import com.example.wini.domain.note.service.NoteService;
 import com.example.wini.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,24 +15,28 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/notes")
+@Tag(name = "2. 마음쪽지 관리", description = "마음쪽지 관련 API")
 @RequiredArgsConstructor
 public class NoteController {
 
   private final NoteService noteService;
 
   @GetMapping("/{noteId}")
+  @Operation(summary = "단일 쪽지 조회", description = "쪽지 내용을 반환합니다.")
   public ResponseEntity<ApiResponse<NoteResponse>> getNote(@PathVariable Long noteId) {
     NoteResponse response = noteService.findNoteById(noteId);
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 
   @GetMapping("/today")
+  @Operation(summary = "오늘 받은 쪽지 리스트 조회", description = "24시간 내 받은 쪽지 목록을 반환합니다.")
   public ResponseEntity<ApiResponse<List<NoteResponse>>> getTodayNotes() {
     List<NoteResponse> responses = noteService.findTodayNotes();
     return ResponseEntity.ok(ApiResponse.success(responses));
   }
 
   @GetMapping("/saved")
+  @Operation(summary = "보관된 쪽지 리스트 조회", description = "사용자가 저장한 쪽지 목록을 반환합니다.")
   public ResponseEntity<ApiResponse<List<NoteResponse>>> getSavedNotes() {
     List<NoteResponse> responses = noteService.findSavedNotes();
     return ResponseEntity.ok(ApiResponse.success(responses));

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
@@ -4,5 +4,7 @@ import com.example.wini.domain.note.domain.Note;
 import java.util.List;
 
 public interface NoteCustomRepository {
+  List<Note> findTodayNotes();
+
   List<Note> findSavedNotes();
 }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -3,7 +3,9 @@ package com.example.wini.domain.note.repository;
 import static com.example.wini.domain.note.domain.QNote.note;
 
 import com.example.wini.domain.note.domain.Note;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
@@ -13,7 +15,16 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
   private final JPAQueryFactory queryFactory;
 
   @Override
+  public List<Note> findTodayNotes() {
+    return queryFactory.selectFrom(note).where(isToday()).fetch();
+  }
+
+  @Override
   public List<Note> findSavedNotes() {
     return queryFactory.selectFrom(note).where(note.isSaved.eq(true)).fetch();
+  }
+
+  private BooleanExpression isToday() {
+    return note.createdAt.after(LocalDateTime.now().minusHours(24));
   }
 }

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -28,6 +28,13 @@ public class NoteService {
   }
 
   @Transactional(readOnly = true)
+  public List<NoteResponse> findTodayNotes() {
+    // TODO : 인가받은 사용자의 노트로 필터링 필요
+    List<Note> notes = noteRepository.findTodayNotes();
+    return notes.stream().map(NoteResponse::from).toList();
+  }
+
+  @Transactional(readOnly = true)
   public List<NoteResponse> findSavedNotes() {
     // TODO : 인가받은 사용자의 노트로 필터링 필요
     List<Note> notes = noteRepository.findSavedNotes();


### PR DESCRIPTION
## 🌱 관련 이슈
- close #8

## 📌 작업 내용 및 특이사항
- 최근 받은 쪽지 리스트 조회 API 구현
- swagger 문구 추가

## 📝 참고사항
- '최근'은 현재를 기준으로 24시간 이내를 의미합니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 오늘 작성된 노트를 조회하는 GET /notes/today 엔드포인트가 추가되었습니다. 최근 24시간 내 생성된 노트 목록을 표준 응답 포맷으로 반환합니다. 기존 엔드포인트 동작에는 변화가 없습니다.
* 문서
  * Note 관련 엔드포인트에 Swagger/OpenAPI 설명을 추가하여 API 문서 가독성과 탐색성을 개선했습니다. 새로운 /notes/today 엔드포인트도 문서화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->