### PR TITLE
feat: 쪽지 생성

### DIFF
--- a/src/main/java/com/example/wini/domain/note/controller/NoteController.java
+++ b/src/main/java/com/example/wini/domain/note/controller/NoteController.java
@@ -30,7 +30,7 @@ public class NoteController {
 
   @GetMapping("/latest")
   @Operation(summary = "최근 받은 쪽지 리스트 조회", description = "24시간 내 받은 쪽지 목록을 반환합니다.")
-  public ResponseEntity<ApiResponse<List<NoteResponse>>> getTodayNotes() {
+  public ResponseEntity<ApiResponse<List<NoteResponse>>> getLatestNotes() {
     List<NoteResponse> responses = noteService.findLatestNotes();
     return ResponseEntity.ok(ApiResponse.success(responses));
   }

--- a/src/main/java/com/example/wini/domain/note/controller/NoteController.java
+++ b/src/main/java/com/example/wini/domain/note/controller/NoteController.java
@@ -47,6 +47,6 @@ public class NoteController {
   public ResponseEntity<ApiResponse<NoteResponse>> createNote(
       @Valid @ModelAttribute NoteCreateRequest request) {
     NoteResponse response = noteService.createNote(request);
-    return ResponseEntity.ok(ApiResponse.success(HttpStatus.CREATED, response));
+    return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
   }
 }

--- a/src/main/java/com/example/wini/domain/note/controller/NoteController.java
+++ b/src/main/java/com/example/wini/domain/note/controller/NoteController.java
@@ -28,10 +28,10 @@ public class NoteController {
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 
-  @GetMapping("/today")
-  @Operation(summary = "오늘 받은 쪽지 리스트 조회", description = "24시간 내 받은 쪽지 목록을 반환합니다.")
+  @GetMapping("/latest")
+  @Operation(summary = "최근 받은 쪽지 리스트 조회", description = "24시간 내 받은 쪽지 목록을 반환합니다.")
   public ResponseEntity<ApiResponse<List<NoteResponse>>> getTodayNotes() {
-    List<NoteResponse> responses = noteService.findTodayNotes();
+    List<NoteResponse> responses = noteService.findLatestNotes();
     return ResponseEntity.ok(ApiResponse.success(responses));
   }
 

--- a/src/main/java/com/example/wini/domain/note/controller/NoteController.java
+++ b/src/main/java/com/example/wini/domain/note/controller/NoteController.java
@@ -1,17 +1,17 @@
 package com.example.wini.domain.note.controller;
 
+import com.example.wini.domain.note.dto.request.NoteCreateRequest;
 import com.example.wini.domain.note.dto.response.NoteResponse;
 import com.example.wini.domain.note.service.NoteService;
 import com.example.wini.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/notes")
@@ -40,5 +40,13 @@ public class NoteController {
   public ResponseEntity<ApiResponse<List<NoteResponse>>> getSavedNotes() {
     List<NoteResponse> responses = noteService.findSavedNotes();
     return ResponseEntity.ok(ApiResponse.success(responses));
+  }
+
+  @PostMapping
+  @Operation(summary = "쪽지 생성", description = "사용자가 쪽지를 생성합니다.")
+  public ResponseEntity<ApiResponse<NoteResponse>> createNote(
+      @Valid @ModelAttribute NoteCreateRequest request) {
+    NoteResponse response = noteService.createNote(request);
+    return ResponseEntity.ok(ApiResponse.success(HttpStatus.CREATED, response));
   }
 }

--- a/src/main/java/com/example/wini/domain/note/dto/request/NoteCreateRequest.java
+++ b/src/main/java/com/example/wini/domain/note/dto/request/NoteCreateRequest.java
@@ -1,0 +1,10 @@
+package com.example.wini.domain.note.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record NoteCreateRequest(
+    @NotNull Long emotionId,
+    Long situationId,
+    @NotNull Long actionId,
+    @NotNull Long promiseId,
+    @NotNull Long closingId) {}

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
@@ -4,6 +4,8 @@ import com.example.wini.domain.note.domain.Note;
 import java.util.List;
 
 public interface NoteCustomRepository {
+  List<Note> findLatestNotes();
+
   List<Note> findTodayNotes();
 
   List<Note> findSavedNotes();

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
@@ -6,7 +6,7 @@ import java.util.List;
 public interface NoteCustomRepository {
   List<Note> findLatestNotes();
 
-  List<Note> findTodayNotes();
-
   List<Note> findSavedNotes();
+
+  Long countTodayNotes();
 }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -5,6 +5,7 @@ import static com.example.wini.domain.note.domain.QNote.note;
 import com.example.wini.domain.note.domain.Note;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,11 @@ import lombok.RequiredArgsConstructor;
 public class NoteCustomRepositoryImpl implements NoteCustomRepository {
 
   private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Note> findLatestNotes() {
+    return queryFactory.selectFrom(note).where(isLatest()).fetch();
+  }
 
   @Override
   public List<Note> findTodayNotes() {
@@ -24,7 +30,12 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     return queryFactory.selectFrom(note).where(note.isSaved.eq(true)).fetch();
   }
 
-  private BooleanExpression isToday() {
+  private BooleanExpression isLatest() {
     return note.createdAt.after(LocalDateTime.now().minusHours(24));
+  }
+
+  private BooleanExpression isToday() {
+    return note.createdAt.between(
+        LocalDate.now().atStartOfDay(), LocalDate.now().plusDays(1).atStartOfDay());
   }
 }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -35,7 +35,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
   }
 
   private BooleanExpression isToday() {
-    return note.createdAt.between(
-        LocalDate.now().atStartOfDay(), LocalDate.now().plusDays(1).atStartOfDay());
+    LocalDateTime start = LocalDate.now().atStartOfDay();
+    LocalDateTime end = LocalDate.now().plusDays(1).atStartOfDay();
+    return note.createdAt.goe(start).and(note.createdAt.lt(end));
   }
 }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -21,13 +21,13 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
   }
 
   @Override
-  public List<Note> findTodayNotes() {
-    return queryFactory.selectFrom(note).where(isToday()).fetch();
+  public List<Note> findSavedNotes() {
+    return queryFactory.selectFrom(note).where(note.isSaved.eq(true)).fetch();
   }
 
   @Override
-  public List<Note> findSavedNotes() {
-    return queryFactory.selectFrom(note).where(note.isSaved.eq(true)).fetch();
+  public Long countTodayNotes() {
+    return queryFactory.select(note.count()).from(note).where(isToday()).fetchFirst();
   }
 
   private BooleanExpression isLatest() {

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -29,9 +29,9 @@ public class NoteService {
   }
 
   @Transactional(readOnly = true)
-  public List<NoteResponse> findTodayNotes() {
+  public List<NoteResponse> findLatestNotes() {
     // TODO : 인가받은 사용자의 노트로 필터링 필요
-    List<Note> notes = noteRepository.findTodayNotes();
+    List<Note> notes = noteRepository.findLatestNotes();
     return notes.stream().map(NoteResponse::from).toList();
   }
 

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -61,7 +61,6 @@ public class NoteService {
 
   private int getNextSequence() {
     // TODO : 인가받은 사용자의 노트로 필터링 필요
-    List<Note> notes = noteRepository.findTodayNotes();
-    return notes.size() + 1;
+    return noteRepository.countTodayNotes().intValue() + 1;
   }
 }

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -56,6 +56,7 @@ public class NoteService {
             request.promiseId(),
             request.closingId(),
             nextSequence);
+    noteRepository.save(note);
     return NoteResponse.from(note);
   }
 

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -3,6 +3,7 @@ package com.example.wini.domain.note.service;
 import static com.example.wini.global.error.exception.ErrorCode.*;
 
 import com.example.wini.domain.note.domain.Note;
+import com.example.wini.domain.note.dto.request.NoteCreateRequest;
 import com.example.wini.domain.note.dto.response.NoteResponse;
 import com.example.wini.domain.note.repository.NoteRepository;
 import com.example.wini.global.error.exception.CustomException;
@@ -39,5 +40,28 @@ public class NoteService {
     // TODO : 인가받은 사용자의 노트로 필터링 필요
     List<Note> notes = noteRepository.findSavedNotes();
     return notes.stream().map(NoteResponse::from).toList();
+  }
+
+  @Transactional(readOnly = false)
+  public NoteResponse createNote(NoteCreateRequest request) {
+    // TODO : 인가받은 사용자로 송신자, 수신자 판단
+    int nextSequence = getNextSequence();
+    Note note =
+        Note.create(
+            1L,
+            2L,
+            request.emotionId(),
+            request.situationId(),
+            request.actionId(),
+            request.promiseId(),
+            request.closingId(),
+            nextSequence);
+    return NoteResponse.from(note);
+  }
+
+  private int getNextSequence() {
+    // TODO : 인가받은 사용자의 노트로 필터링 필요
+    List<Note> notes = noteRepository.findTodayNotes();
+    return notes.size() + 1;
   }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #18

## 📌 작업 내용 및 특이사항
- 쪽지 생성 API 구현
- '최근' 받은 쪽지와 '오늘' 받은 쪽지 분리

## 📝 참고사항
- 상황 ID는 이전에 상의했던 대로 `null`을 허용하게끔 구현했습니다.
- 혼동을 방지하기 위해 최근 받은 쪽지 API 엔드포인트를 변경했습니다. (today -> latest)

## 📚 기타
- http 상태코드를 중복 작성하지 않고 공통 응답 객체를 보낼 수 있는 방법 논의 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 노트 생성 API 추가: POST /notes. 필수 입력값 유효성 검사를 적용하고, 생성 시 201 Created로 표준 응답을 반환합니다.
- **Refactor**
  - 최신 노트 조회로 명칭·경로 변경: GET /notes/today → GET /notes/latest. 기준을 “오늘”에서 최근 24시간 기준의 최신 항목으로 조정했습니다.
  - 기존 상세 조회(GET /notes/{noteId}) 및 저장된 노트 조회(GET /notes/saved)는 변경 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->