### PR TITLE
feat: 내 상태 수정

### DIFF
--- a/src/main/java/com/example/wini/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/wini/domain/member/controller/MemberController.java
@@ -1,13 +1,17 @@
 package com.example.wini.domain.member.controller;
 
+import com.example.wini.domain.member.dto.request.MemberStatusUpdateRequest;
 import com.example.wini.domain.member.dto.response.MemberStatusResponse;
 import com.example.wini.domain.member.service.MemberService;
 import com.example.wini.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -34,6 +38,15 @@ public class MemberController {
       // TODO: 토큰이 생기면 사용자 정보 추출하기
       ) {
     MemberStatusResponse response = memberService.searchMateStatus();
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+  @Operation(summary = "내 상태 수정", description = "수정한 상태를 반환합니다. '계속 유지'의 경우 시간과 분은 -1로 입력해주세요.")
+  @PutMapping("/me/status")
+  public ResponseEntity<ApiResponse<MemberStatusResponse>> putStatus(
+      // TODO: 토큰이 생기면 사용자 정보 추출하기
+      @Valid @RequestBody MemberStatusUpdateRequest request) {
+    MemberStatusResponse response = memberService.updateStatus(request);
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 }

--- a/src/main/java/com/example/wini/domain/member/domain/Member.java
+++ b/src/main/java/com/example/wini/domain/member/domain/Member.java
@@ -50,4 +50,10 @@ public class Member extends BaseEntity {
   private LocalDateTime statusStartedAt;
 
   private Long statusDuration;
+
+  public void updateStatus(Status status, LocalDateTime statusStartedAt, Long statusDuration) {
+    this.status = status;
+    this.statusStartedAt = statusStartedAt;
+    this.statusDuration = statusDuration;
+  }
 }

--- a/src/main/java/com/example/wini/domain/member/dto/common/ReservedTimeInfo.java
+++ b/src/main/java/com/example/wini/domain/member/dto/common/ReservedTimeInfo.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
 
 public record ReservedTimeInfo(
-    @NotNull @Min(value = -1) @Max(value = 59) Long hour,
+    @NotNull @Min(value = -1) @Max(value = 24) Long hour,
     @NotNull @Min(value = -1) @Max(value = 59) Long minute) {
   public static ReservedTimeInfo of(long hour, long minute) {
     return new ReservedTimeInfo(hour, minute);

--- a/src/main/java/com/example/wini/domain/member/dto/common/ReservedTimeInfo.java
+++ b/src/main/java/com/example/wini/domain/member/dto/common/ReservedTimeInfo.java
@@ -1,7 +1,22 @@
 package com.example.wini.domain.member.dto.common;
 
-public record ReservedTimeInfo(Long hour, Long minute) {
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
+
+public record ReservedTimeInfo(
+    @NotNull @Min(value = -1) @Max(value = 59) Long hour,
+    @NotNull @Min(value = -1) @Max(value = 59) Long minute) {
   public static ReservedTimeInfo of(long hour, long minute) {
     return new ReservedTimeInfo(hour, minute);
+  }
+
+  public Duration toDuration() {
+    if (this.hour == -1 && this.minute == -1) {
+      return Duration.ofDays(365L * 100);
+    }
+
+    return Duration.ofHours(this.hour).plusMinutes(this.minute);
   }
 }

--- a/src/main/java/com/example/wini/domain/member/dto/common/ReservedTimeInfo.java
+++ b/src/main/java/com/example/wini/domain/member/dto/common/ReservedTimeInfo.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
 
 public record ReservedTimeInfo(
-    @NotNull @Min(value = -1) @Max(value = 24) Long hour,
+    @NotNull @Min(value = -1) @Max(value = 12) Long hour,
     @NotNull @Min(value = -1) @Max(value = 59) Long minute) {
   public static ReservedTimeInfo of(long hour, long minute) {
     return new ReservedTimeInfo(hour, minute);

--- a/src/main/java/com/example/wini/domain/member/dto/request/MemberStatusUpdateRequest.java
+++ b/src/main/java/com/example/wini/domain/member/dto/request/MemberStatusUpdateRequest.java
@@ -1,10 +1,11 @@
 package com.example.wini.domain.member.dto.request;
 
 import com.example.wini.domain.member.dto.common.ReservedTimeInfo;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 public record MemberStatusUpdateRequest(
     @NotNull Long statusId,
     @NotNull LocalDateTime startedAt,
-    @NotNull ReservedTimeInfo reservedTimeInfo) {}
+    @NotNull @Valid ReservedTimeInfo reservedTimeInfo) {}

--- a/src/main/java/com/example/wini/domain/member/dto/request/MemberStatusUpdateRequest.java
+++ b/src/main/java/com/example/wini/domain/member/dto/request/MemberStatusUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.example.wini.domain.member.dto.request;
+
+import com.example.wini.domain.member.dto.common.ReservedTimeInfo;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record MemberStatusUpdateRequest(
+    @NotNull Long statusId,
+    @NotNull LocalDateTime startedAt,
+    @NotNull ReservedTimeInfo reservedTimeInfo) {}

--- a/src/main/java/com/example/wini/domain/member/repository/MemberCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/member/repository/MemberCustomRepository.java
@@ -4,7 +4,7 @@ import com.example.wini.domain.member.domain.Member;
 import java.util.Optional;
 
 public interface MemberCustomRepository {
-    Optional<Member> findWithStatusByMemberId(Long memberId);
+  Optional<Member> findWithStatusByMemberId(Long memberId);
 
-    Optional<Member> findRoommateInMyRoom(Long memberId, Long roomId);
+  Optional<Member> findRoommateInMyRoom(Long memberId, Long roomId);
 }

--- a/src/main/java/com/example/wini/domain/member/repository/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/member/repository/MemberCustomRepositoryImpl.java
@@ -13,27 +13,27 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
 
   private final JPAQueryFactory queryFactory;
 
-    @Override
-    public Optional<Member> findWithStatusByMemberId(Long memberId) {
-        return Optional.ofNullable(
-            queryFactory
-                .selectFrom(member)
-                .join(member.status)
-                .fetchJoin()
-                .where(member.id.eq(memberId))
-                .fetchOne());
-    }
+  @Override
+  public Optional<Member> findWithStatusByMemberId(Long memberId) {
+    return Optional.ofNullable(
+        queryFactory
+            .selectFrom(member)
+            .join(member.status)
+            .fetchJoin()
+            .where(member.id.eq(memberId))
+            .fetchOne());
+  }
 
-    @Override
-    public Optional<Member> findRoommateInMyRoom(Long memberId, Long roomId) {
-        return Optional.ofNullable(
-            queryFactory
-                .selectFrom(member)
-                .join(memberRoom)
-                .on(memberRoom.member.id.eq(member.id))
-                .join(member.status)
-                .fetchJoin()
-                .where(memberRoom.room.id.in(roomId).and(memberRoom.member.id.ne(memberId)))
-                .fetchOne());
-    }
+  @Override
+  public Optional<Member> findRoommateInMyRoom(Long memberId, Long roomId) {
+    return Optional.ofNullable(
+        queryFactory
+            .selectFrom(member)
+            .join(memberRoom)
+            .on(memberRoom.member.id.eq(member.id))
+            .join(member.status)
+            .fetchJoin()
+            .where(memberRoom.room.id.in(roomId).and(memberRoom.member.id.ne(memberId)))
+            .fetchOne());
+  }
 }

--- a/src/main/java/com/example/wini/domain/member/repository/StatusRepository.java
+++ b/src/main/java/com/example/wini/domain/member/repository/StatusRepository.java
@@ -1,0 +1,6 @@
+package com.example.wini.domain.member.repository;
+
+import com.example.wini.domain.member.domain.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StatusRepository extends JpaRepository<Status, Long> {}

--- a/src/main/java/com/example/wini/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/wini/domain/member/service/MemberService.java
@@ -2,11 +2,15 @@ package com.example.wini.domain.member.service;
 
 import static com.example.wini.global.error.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static com.example.wini.global.error.exception.ErrorCode.ROOM_NOT_FOUND;
+import static com.example.wini.global.error.exception.ErrorCode.STATUS_NOT_FOUND;
 
 import com.example.wini.domain.member.domain.Member;
+import com.example.wini.domain.member.domain.Status;
 import com.example.wini.domain.member.dto.common.ReservedTimeInfo;
+import com.example.wini.domain.member.dto.request.MemberStatusUpdateRequest;
 import com.example.wini.domain.member.dto.response.MemberStatusResponse;
 import com.example.wini.domain.member.repository.MemberRepository;
+import com.example.wini.domain.member.repository.StatusRepository;
 import com.example.wini.domain.room.repository.RoomRepository;
 import com.example.wini.global.error.exception.CustomException;
 import java.time.Duration;
@@ -21,9 +25,11 @@ public class MemberService {
 
   private final MemberRepository memberRepository;
   private final RoomRepository roomRepository;
+  private final StatusRepository statusRepository;
 
   private static final Long MEMBER_ID = 1L;
 
+  @Transactional(readOnly = true)
   public MemberStatusResponse searchMyStatus() {
     Member member =
         memberRepository
@@ -73,5 +79,25 @@ public class MemberService {
   private ReservedTimeInfo createReservedTimeInfo(long durationSeconds) {
     Duration duration = Duration.ofSeconds(durationSeconds);
     return ReservedTimeInfo.of(duration.toHours(), duration.toMinutes() % 60);
+  }
+
+  @Transactional
+  public MemberStatusResponse updateStatus(MemberStatusUpdateRequest request) {
+    Member member =
+        memberRepository
+            .findById(MEMBER_ID)
+            .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+    Status status =
+        statusRepository
+            .findById(request.statusId())
+            .orElseThrow(() -> new CustomException(STATUS_NOT_FOUND));
+
+    Duration statusDuration = request.reservedTimeInfo().toDuration();
+    Long statusDurationSeconds = statusDuration.getSeconds();
+
+    member.updateStatus(status, request.startedAt(), statusDurationSeconds);
+
+    return MemberStatusResponse.from(member, request.reservedTimeInfo());
   }
 }

--- a/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
@@ -23,6 +23,9 @@ public enum ErrorCode {
   // Member
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
 
+  // Status
+  STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상태입니다."),
+
   // Room
   ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 방입니다."),
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #10 

## 📌 작업 내용 및 특이사항
- 내 상태 수정 API 구현

## 📝 참고사항
- 마지막 [커밋](https://github.com/dnd-side-project/dnd-13th-4-backend/commit/b0609ff29e17fc971b1edfbf9b6e5ee64365d8ba)은 병합 과정에서 Spotless가 적용되지 않은 코드가 들어와서 일관성을 위해 Spotless 포맷팅을 재적용한 커밋입니다

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 내 상태 업데이트 API 추가: 사용자가 자신의 상태, 시작 시각 및 유지 시간을 설정/저장할 수 있습니다.
  * 상태 저장소 추가로 상태 선택/조회 지원.
  * 요청 데이터 유효성 강화: 시간/분 값 범위 검사 및 @Valid 적용.
  * 유지 시간 처리: (-1, -1)은 무기한으로 간주, 정상 값은 Duration으로 변환.
  * 존재하지 않는 상태 선택 시 404 응답 반환.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->