### PR TITLE
chore: mysql 연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // Database
+    runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'
 
     // swagger

--- a/src/main/resources/application-mysql.yml
+++ b/src/main/resources/application-mysql.yml
@@ -1,0 +1,9 @@
+spring:
+  config:
+    activate:
+      on-profile: "mysql"
+  datasource:
+    url: jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,8 @@
 spring:
   profiles:
     group:
-      dev: "dev, h2"
+      dev: "dev, mysql"
+      test: "h2"
     include:
       - swagger
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #38

## 📌 작업 내용 및 특이사항
- mysql 연결
- dev 그룹 프로파일 DB를 h2에서 mysql로 변경

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 애플리케이션에서 MySQL 데이터베이스 연결을 지원하도록 런타임 드라이버를 추가했습니다. 프로덕션 등 런타임 환경에서 MySQL 사용이 가능합니다.
- 작업(Chores)
  - 빌드 설정에 런타임 의존성을 추가했습니다. 컴파일 단계에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->