### PR TITLE
feat: 초대코드 생성

### DIFF
--- a/src/main/java/com/example/wini/domain/room/controller/RoomController.java
+++ b/src/main/java/com/example/wini/domain/room/controller/RoomController.java
@@ -1,0 +1,34 @@
+package com.example.wini.domain.room.controller;
+
+import com.example.wini.domain.room.dto.response.RoomResponse;
+import com.example.wini.domain.room.service.RoomService;
+import com.example.wini.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/rooms")
+@Tag(name = "5. 방 관리", description = "방 관련 API")
+@RequiredArgsConstructor
+public class RoomController {
+
+  private static final Long MEMBER_ID = 1L;
+
+  private final RoomService roomService;
+
+  @Operation(summary = "초대코드 생성", description = "생성된 초대코드를 반환합니다.")
+  @PostMapping
+  public ResponseEntity<ApiResponse<RoomResponse>> createRoom(
+      // TODO: 토큰이 생기면 사용자 정보 추출하기
+      ) {
+    RoomResponse response = roomService.createRoom(MEMBER_ID);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResponse.success(HttpStatus.CREATED, response));
+  }
+}

--- a/src/main/java/com/example/wini/domain/room/dto/response/RoomResponse.java
+++ b/src/main/java/com/example/wini/domain/room/dto/response/RoomResponse.java
@@ -1,0 +1,9 @@
+package com.example.wini.domain.room.dto.response;
+
+import com.example.wini.domain.room.entity.Room;
+
+public record RoomResponse(Long id, String code) {
+  public static RoomResponse from(Room room) {
+    return new RoomResponse(room.getId(), room.getRoomCode());
+  }
+}

--- a/src/main/java/com/example/wini/domain/room/entity/MemberRoom.java
+++ b/src/main/java/com/example/wini/domain/room/entity/MemberRoom.java
@@ -31,4 +31,13 @@ public class MemberRoom extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "room_id")
   private Room room;
+
+  private MemberRoom(Member member, Room room) {
+    this.member = member;
+    this.room = room;
+  }
+
+  public static MemberRoom create(Member member, Room room) {
+    return new MemberRoom(member, room);
+  }
 }

--- a/src/main/java/com/example/wini/domain/room/entity/Room.java
+++ b/src/main/java/com/example/wini/domain/room/entity/Room.java
@@ -26,4 +26,13 @@ public class Room extends BaseEntity {
 
   @Column(nullable = false)
   private Boolean isClosed;
+
+  private Room(String roomCode) {
+    this.roomCode = roomCode;
+    this.isClosed = false;
+  }
+
+  public static Room create(String roomCode) {
+    return new Room(roomCode);
+  }
 }

--- a/src/main/java/com/example/wini/domain/room/repository/MemberRoomRepository.java
+++ b/src/main/java/com/example/wini/domain/room/repository/MemberRoomRepository.java
@@ -1,0 +1,6 @@
+package com.example.wini.domain.room.repository;
+
+import com.example.wini.domain.room.entity.MemberRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {}

--- a/src/main/java/com/example/wini/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/example/wini/domain/room/repository/RoomRepository.java
@@ -3,4 +3,7 @@ package com.example.wini.domain.room.repository;
 import com.example.wini.domain.room.entity.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RoomRepository extends JpaRepository<Room, Long>, RoomCustomRepository {}
+public interface RoomRepository extends JpaRepository<Room, Long>, RoomCustomRepository {
+
+  boolean existsByRoomCode(String roomCode);
+}

--- a/src/main/java/com/example/wini/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/wini/domain/room/service/RoomService.java
@@ -1,0 +1,65 @@
+package com.example.wini.domain.room.service;
+
+import static com.example.wini.global.error.exception.ErrorCode.MEMBER_NOT_FOUND;
+
+import com.example.wini.domain.member.domain.Member;
+import com.example.wini.domain.member.repository.MemberRepository;
+import com.example.wini.domain.room.dto.response.RoomResponse;
+import com.example.wini.domain.room.entity.MemberRoom;
+import com.example.wini.domain.room.entity.Room;
+import com.example.wini.domain.room.repository.MemberRoomRepository;
+import com.example.wini.domain.room.repository.RoomRepository;
+import com.example.wini.global.error.exception.CustomException;
+import java.security.SecureRandom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RoomService {
+
+  private static final Integer ROOM_CODE_LENGTH = 7;
+
+  private final MemberRepository memberRepository;
+  private final RoomRepository roomRepository;
+  private final MemberRoomRepository memberRoomRepository;
+
+  @Transactional
+  public RoomResponse createRoom(Long memberId) {
+    Member member =
+        memberRepository
+            .findById(memberId)
+            .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+    String roomCode = generateUniqueRoomCode();
+
+    Room room = Room.create(roomCode);
+    Room saveRoom = roomRepository.save(room);
+
+    MemberRoom memberRoom = MemberRoom.create(member, room);
+    memberRoomRepository.save(memberRoom);
+
+    return RoomResponse.from(saveRoom);
+  }
+
+  private String generateUniqueRoomCode() {
+    String roomCode;
+    do {
+      roomCode = generateRoomCode();
+    } while (roomRepository.existsByRoomCode(roomCode));
+    return roomCode;
+  }
+
+  private String generateRoomCode() {
+    String charSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    SecureRandom random = new SecureRandom();
+    StringBuilder codeBuilder = new StringBuilder(ROOM_CODE_LENGTH);
+
+    for (int i = 0; i < ROOM_CODE_LENGTH; i++) {
+      int index = random.nextInt(charSet.length());
+      codeBuilder.append(charSet.charAt(index));
+    }
+    return codeBuilder.toString();
+  }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #19 

## 📌 작업 내용 및 특이사항
- 초대코드 생성 API 구현

## 📝 참고사항
- 초대코드 생성 시 ui에서는 대문자 + 숫자 조합이라 소문자는 제외했습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 방 생성 API가 추가되었습니다. 사용자는 요청을 통해 새 방을 만들고, 고유한 7자리 초대 코드를 포함한 정보를 응답으로 받을 수 있습니다.
- 문서
  - 새 엔드포인트가 OpenAPI 문서에 반영되어, 사용과 응답 형식을 쉽게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->