### PR TITLE
feat: 감정 리스트 조회

### DIFF
--- a/src/main/java/com/example/wini/domain/note/domain/Note.java
+++ b/src/main/java/com/example/wini/domain/note/domain/Note.java
@@ -1,6 +1,7 @@
 package com.example.wini.domain.note.domain;
 
 import com.example.wini.domain.common.BaseEntity;
+import com.example.wini.domain.template.domain.Emotion;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -22,8 +23,9 @@ public class Note extends BaseEntity {
   @Column(nullable = false)
   private Long memberRoomReceiverId;
 
-  @Column(nullable = false)
-  private Long emotionId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "emotion_id")
+  private Emotion emotion;
 
   @Column(nullable = true)
   private Long situationId;
@@ -50,7 +52,7 @@ public class Note extends BaseEntity {
   private Note(
       Long memberRoomSenderId,
       Long memberRoomReceiverId,
-      Long emotionId,
+      Emotion emotion,
       Long situationId,
       Long actionId,
       Long promiseId,
@@ -58,7 +60,7 @@ public class Note extends BaseEntity {
       int sequence) {
     this.memberRoomSenderId = memberRoomSenderId;
     this.memberRoomReceiverId = memberRoomReceiverId;
-    this.emotionId = emotionId;
+    this.emotion = emotion;
     this.situationId = situationId;
     this.actionId = actionId;
     this.promiseId = promiseId;
@@ -71,7 +73,7 @@ public class Note extends BaseEntity {
   public static Note create(
       Long memberRoomSenderId,
       Long memberRoomReceiverId,
-      Long emotionId,
+      Emotion emotion,
       Long situationId,
       Long actionId,
       Long promiseId,
@@ -80,7 +82,7 @@ public class Note extends BaseEntity {
     return Note.builder()
         .memberRoomSenderId(memberRoomSenderId)
         .memberRoomReceiverId(memberRoomReceiverId)
-        .emotionId(emotionId)
+        .emotion(emotion)
         .situationId(situationId)
         .actionId(actionId)
         .promiseId(promiseId)

--- a/src/main/java/com/example/wini/domain/note/domain/Note.java
+++ b/src/main/java/com/example/wini/domain/note/domain/Note.java
@@ -17,6 +17,7 @@ public class Note extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  // TODO : 인증인가 후 MemberRoom 연결
   @Column(nullable = false)
   private Long memberRoomSenderId;
 

--- a/src/main/java/com/example/wini/domain/note/dto/response/NoteResponse.java
+++ b/src/main/java/com/example/wini/domain/note/dto/response/NoteResponse.java
@@ -19,7 +19,7 @@ public record NoteResponse(
         note.getId(),
         note.getMemberRoomSenderId(),
         note.getMemberRoomReceiverId(),
-        note.getEmotionId(),
+        note.getEmotion().getId(),
         note.getSituationId(),
         note.getActionId(),
         note.getPromiseId(),

--- a/src/main/java/com/example/wini/domain/note/dto/response/NoteResponse.java
+++ b/src/main/java/com/example/wini/domain/note/dto/response/NoteResponse.java
@@ -1,6 +1,7 @@
 package com.example.wini.domain.note.dto.response;
 
 import com.example.wini.domain.note.domain.Note;
+import java.time.LocalDateTime;
 
 public record NoteResponse(
     Long id,
@@ -13,7 +14,8 @@ public record NoteResponse(
     Long closingId,
     int sequence,
     boolean isRead,
-    boolean isSaved) {
+    boolean isSaved,
+    LocalDateTime createdAt) {
   public static NoteResponse from(Note note) {
     return new NoteResponse(
         note.getId(),
@@ -26,6 +28,7 @@ public record NoteResponse(
         note.getClosingId(),
         note.getSequence(),
         note.isRead(),
-        note.isSaved());
+        note.isSaved(),
+        note.getCreatedAt());
   }
 }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
@@ -2,8 +2,11 @@ package com.example.wini.domain.note.repository;
 
 import com.example.wini.domain.note.domain.Note;
 import java.util.List;
+import java.util.Optional;
 
 public interface NoteCustomRepository {
+  Optional<Note> findWithEmotionByNoteId(Long noteId);
+
   List<Note> findLatestNotes();
 
   List<Note> findSavedNotes();

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -8,12 +8,24 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class NoteCustomRepositoryImpl implements NoteCustomRepository {
 
   private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Optional<Note> findWithEmotionByNoteId(Long noteId) {
+    return Optional.ofNullable(
+        queryFactory
+            .selectFrom(note)
+            .join(note.emotion)
+            .fetchJoin()
+            .where(note.id.eq(noteId))
+            .fetchOne());
+  }
 
   @Override
   public List<Note> findLatestNotes() {

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -6,6 +6,8 @@ import com.example.wini.domain.note.domain.Note;
 import com.example.wini.domain.note.dto.request.NoteCreateRequest;
 import com.example.wini.domain.note.dto.response.NoteResponse;
 import com.example.wini.domain.note.repository.NoteRepository;
+import com.example.wini.domain.template.domain.Emotion;
+import com.example.wini.domain.template.repository.EmotionRepository;
 import com.example.wini.global.error.exception.CustomException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NoteService {
 
   private final NoteRepository noteRepository;
+  private final EmotionRepository emotionRepository;
 
   @Transactional(readOnly = true)
   public NoteResponse findNoteById(Long noteId) {
@@ -45,17 +48,7 @@ public class NoteService {
   @Transactional(readOnly = false)
   public NoteResponse createNote(NoteCreateRequest request) {
     // TODO : 인가받은 사용자로 송신자, 수신자 판단
-    int nextSequence = getNextSequence();
-    Note note =
-        Note.create(
-            1L,
-            2L,
-            request.emotionId(),
-            request.situationId(),
-            request.actionId(),
-            request.promiseId(),
-            request.closingId(),
-            nextSequence);
+    Note note = buildNewNote(request);
     noteRepository.save(note);
     return NoteResponse.from(note);
   }
@@ -67,6 +60,24 @@ public class NoteService {
         noteRepository.findById(noteId).orElseThrow(() -> new CustomException(NOTE_NOT_FOUND));
     note.markAsSaved();
     return NoteResponse.from(note);
+  }
+
+  private Note buildNewNote(NoteCreateRequest request) {
+    Emotion emotion =
+        emotionRepository
+            .findById(request.emotionId())
+            .orElseThrow(() -> new CustomException(EMOTION_NOT_FOUND));
+    int nextSequence = getNextSequence();
+
+    return Note.create(
+        1L,
+        2L,
+        emotion,
+        request.situationId(),
+        request.actionId(),
+        request.promiseId(),
+        request.closingId(),
+        nextSequence);
   }
 
   private int getNextSequence() {

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -26,7 +26,9 @@ public class NoteService {
   @Transactional(readOnly = true)
   public NoteResponse findNoteById(Long noteId) {
     Note note =
-        noteRepository.findById(noteId).orElseThrow(() -> new CustomException(NOTE_NOT_FOUND));
+        noteRepository
+            .findWithEmotionByNoteId(noteId)
+            .orElseThrow(() -> new CustomException(NOTE_NOT_FOUND));
     // TODO : 인가받은 사용자 확인 후 읽음 처리 필요
     return NoteResponse.from(note);
   }

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -47,7 +47,6 @@ public class NoteService {
 
   @Transactional(readOnly = false)
   public NoteResponse createNote(NoteCreateRequest request) {
-    // TODO : 인가받은 사용자로 송신자, 수신자 판단
     Note note = buildNewNote(request);
     noteRepository.save(note);
     return NoteResponse.from(note);
@@ -63,6 +62,7 @@ public class NoteService {
   }
 
   private Note buildNewNote(NoteCreateRequest request) {
+    // TODO : 인가받은 사용자로 송신자, 수신자 판단
     Emotion emotion =
         emotionRepository
             .findById(request.emotionId())

--- a/src/main/java/com/example/wini/domain/template/controller/TemplateController.java
+++ b/src/main/java/com/example/wini/domain/template/controller/TemplateController.java
@@ -1,0 +1,29 @@
+package com.example.wini.domain.template.controller;
+
+import com.example.wini.domain.template.dto.response.EmotionResponse;
+import com.example.wini.domain.template.service.EmotionService;
+import com.example.wini.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping
+@Tag(name = "3. 템플릿 관리", description = "템플릿 관련 API")
+@RequiredArgsConstructor
+public class TemplateController {
+
+  private final EmotionService emotionService;
+
+  @GetMapping("/emotions")
+  @Operation(summary = "감정 리스트 조회", description = "감정 목록을 반환합니다.")
+  public ResponseEntity<ApiResponse<List<EmotionResponse>>> getEmotions() {
+    List<EmotionResponse> responses = emotionService.findAllEmotions();
+    return ResponseEntity.ok(ApiResponse.success(responses));
+  }
+}

--- a/src/main/java/com/example/wini/domain/template/controller/TemplateController.java
+++ b/src/main/java/com/example/wini/domain/template/controller/TemplateController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping
+@RequestMapping("/templates")
 @Tag(name = "3. 템플릿 관리", description = "템플릿 관련 API")
 @RequiredArgsConstructor
 public class TemplateController {

--- a/src/main/java/com/example/wini/domain/template/domain/Emotion.java
+++ b/src/main/java/com/example/wini/domain/template/domain/Emotion.java
@@ -1,5 +1,6 @@
 package com.example.wini.domain.template.domain;
 
+import com.example.wini.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Emotion {
+public class Emotion extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/wini/domain/template/domain/Emotion.java
+++ b/src/main/java/com/example/wini/domain/template/domain/Emotion.java
@@ -1,0 +1,38 @@
+package com.example.wini.domain.template.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Emotion {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(length = 10, nullable = false)
+  @Enumerated(EnumType.STRING)
+  private EmotionType emotionType;
+
+  @Column(length = 10, nullable = false)
+  private String text;
+
+  @Column(nullable = false)
+  private String graphicUrl;
+
+  @Builder(access = AccessLevel.PRIVATE)
+  private Emotion(EmotionType emotionType, String text, String graphicUrl) {
+    this.emotionType = emotionType;
+    this.text = text;
+    this.graphicUrl = graphicUrl;
+  }
+
+  public static Emotion create(EmotionType emotionType, String text, String graphicUrl) {
+    return Emotion.builder().emotionType(emotionType).text(text).graphicUrl(graphicUrl).build();
+  }
+}

--- a/src/main/java/com/example/wini/domain/template/domain/EmotionType.java
+++ b/src/main/java/com/example/wini/domain/template/domain/EmotionType.java
@@ -1,0 +1,14 @@
+package com.example.wini.domain.template.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EmotionType {
+  POSITIVE("긍정"),
+  NEGATIVE("부정"),
+  ;
+
+  private final String value;
+}

--- a/src/main/java/com/example/wini/domain/template/dto/response/EmotionResponse.java
+++ b/src/main/java/com/example/wini/domain/template/dto/response/EmotionResponse.java
@@ -1,0 +1,13 @@
+package com.example.wini.domain.template.dto.response;
+
+import com.example.wini.domain.template.domain.Emotion;
+
+public record EmotionResponse(Long id, String emotionType, String text, String graphicUrl) {
+  public static EmotionResponse from(Emotion emotion) {
+    return new EmotionResponse(
+        emotion.getId(),
+        emotion.getEmotionType().getValue(),
+        emotion.getText(),
+        emotion.getGraphicUrl());
+  }
+}

--- a/src/main/java/com/example/wini/domain/template/repository/EmotionRepository.java
+++ b/src/main/java/com/example/wini/domain/template/repository/EmotionRepository.java
@@ -1,0 +1,6 @@
+package com.example.wini.domain.template.repository;
+
+import com.example.wini.domain.template.domain.Emotion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmotionRepository extends JpaRepository<Emotion, Long> {}

--- a/src/main/java/com/example/wini/domain/template/service/EmotionService.java
+++ b/src/main/java/com/example/wini/domain/template/service/EmotionService.java
@@ -1,0 +1,24 @@
+package com.example.wini.domain.template.service;
+
+import com.example.wini.domain.template.domain.Emotion;
+import com.example.wini.domain.template.dto.response.EmotionResponse;
+import com.example.wini.domain.template.repository.EmotionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmotionService {
+
+  private final EmotionRepository emotionRepository;
+
+  @Transactional(readOnly = true)
+  public List<EmotionResponse> findAllEmotions() {
+    List<Emotion> emotions = emotionRepository.findAll();
+    return emotions.stream().map(EmotionResponse::from).toList();
+  }
+}

--- a/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
@@ -31,6 +31,9 @@ public enum ErrorCode {
 
   // Note
   NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 마음쪽지입니다."),
+
+  // Template
+  EMOTION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 감정입니다."),
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: "dev"
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 🌱 관련 이슈
- close #13

## 📌 작업 내용 및 특이사항
- 템플릿 도메인 추가
- 감정 엔티티 추가 및 쪽지에 연결
- 감정 리스트 조회 API 구현
- 쪽지 응답 dto에 생성시간 추가

## 📝 참고사항
- 감정분류는 엔티티 대신 enum으로 관리하였습니다.
- 템플릿 관련 API를 한번에 관리하기 위해 `TemplateController`로 명명하였습니다.

## 📚 기타
- API의 일관성을 위해 템플릿 관련 API 엔드포인트에 `/templates`를 추가할지 고민입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 감정(Emotion) 엔티티 및 EmotionType 열거 추가, 감정 조회 API(/templates/emotions)와 감정 DTO/리포지토리/서비스 추가.
  * 노트가 감정 엔티티를 참조하도록 변경되어 응답에 emotionId 반영 및 Note 생성 로직에서 감정 검증 수행.
  * NoteResponse에 createdAt(생성 일시) 필드 추가.
  * 노트 조회용 findWithEmotionByNoteId(Optional) 리포지토리 메서드 추가.

* **Bug Fixes**
  * 존재하지 않는 감정으로 노트 생성 시 404(EMOTION_NOT_FOUND) 반환.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->