### PR TITLE
feat: 초대코드 입력

### DIFF
--- a/src/main/java/com/example/wini/domain/member/repository/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/member/repository/MemberCustomRepositoryImpl.java
@@ -17,7 +17,7 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
     public Optional<Member> findWithStatusByMemberId(Long memberId) {
         return Optional.ofNullable(queryFactory
                 .selectFrom(member)
-                .join(member.status)
+                .leftJoin(member.status)
                 .fetchJoin()
                 .where(member.id.eq(memberId))
                 .fetchOne());
@@ -29,7 +29,7 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
                 .selectFrom(member)
                 .join(memberRoom)
                 .on(memberRoom.member.id.eq(member.id))
-                .join(member.status)
+                .leftJoin(member.status)
                 .fetchJoin()
                 .where(memberRoom.room.id.in(roomId).and(memberRoom.member.id.ne(memberId)))
                 .fetchOne());

--- a/src/main/java/com/example/wini/domain/room/controller/RoomController.java
+++ b/src/main/java/com/example/wini/domain/room/controller/RoomController.java
@@ -38,8 +38,8 @@ public class RoomController {
     @Operation(summary = "초대코드 입력", description = "초대코드와 연결된 방 정보를 반환합니다.")
     @PostMapping("/join")
     public ResponseEntity<ApiResponse<RoomResponse>> joinRoom(
-        // TODO: 토큰이 생기면 사용자 정보 추출하기
-        @Valid @RequestBody RoomJoinRequest request) {
+            // TODO: 토큰이 생기면 사용자 정보 추출하기
+            @Valid @RequestBody RoomJoinRequest request) {
         RoomResponse response = roomService.joinRoom(MATE_ID, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(HttpStatus.CREATED, response));
     }

--- a/src/main/java/com/example/wini/domain/room/controller/RoomController.java
+++ b/src/main/java/com/example/wini/domain/room/controller/RoomController.java
@@ -1,14 +1,17 @@
 package com.example.wini.domain.room.controller;
 
+import com.example.wini.domain.room.dto.request.RoomJoinRequest;
 import com.example.wini.domain.room.dto.response.RoomResponse;
 import com.example.wini.domain.room.service.RoomService;
 import com.example.wini.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RoomController {
 
     private static final Long MEMBER_ID = 1L;
+    private static final Long MATE_ID = 2L;
 
     private final RoomService roomService;
 
@@ -28,6 +32,15 @@ public class RoomController {
             // TODO: 토큰이 생기면 사용자 정보 추출하기
             ) {
         RoomResponse response = roomService.createRoom(MEMBER_ID);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(HttpStatus.CREATED, response));
+    }
+
+    @Operation(summary = "초대코드 입력", description = "초대코드와 연결된 방 정보를 반환합니다.")
+    @PostMapping("/join")
+    public ResponseEntity<ApiResponse<RoomResponse>> joinRoom(
+        // TODO: 토큰이 생기면 사용자 정보 추출하기
+        @Valid @RequestBody RoomJoinRequest request) {
+        RoomResponse response = roomService.joinRoom(MATE_ID, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(HttpStatus.CREATED, response));
     }
 }

--- a/src/main/java/com/example/wini/domain/room/dto/request/RoomJoinRequest.java
+++ b/src/main/java/com/example/wini/domain/room/dto/request/RoomJoinRequest.java
@@ -1,0 +1,5 @@
+package com.example.wini.domain.room.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RoomJoinRequest(@NotBlank String roomCode) {}

--- a/src/main/java/com/example/wini/domain/room/repository/MemberRoomRepository.java
+++ b/src/main/java/com/example/wini/domain/room/repository/MemberRoomRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
 
-  Long countMembersByRoomId(Long roomId);
+  long countMembersByRoomId(Long roomId);
 }

--- a/src/main/java/com/example/wini/domain/room/repository/MemberRoomRepository.java
+++ b/src/main/java/com/example/wini/domain/room/repository/MemberRoomRepository.java
@@ -3,4 +3,7 @@ package com.example.wini.domain.room.repository;
 import com.example.wini.domain.room.entity.MemberRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {}
+public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
+
+  Long countMembersByRoomId(Long roomId);
+}

--- a/src/main/java/com/example/wini/domain/room/repository/MemberRoomRepository.java
+++ b/src/main/java/com/example/wini/domain/room/repository/MemberRoomRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
 
-  long countMembersByRoomId(Long roomId);
+    long countMembersByRoomId(Long roomId);
 }

--- a/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepository.java
@@ -4,9 +4,9 @@ import com.example.wini.domain.room.entity.Room;
 import java.util.Optional;
 
 public interface RoomCustomRepository {
-   Optional<Long> findOpenRoomIdByMemberId(Long memberId);
+    Optional<Long> findOpenRoomIdByMemberId(Long memberId);
 
-  Optional<Room> findOpenRoomByRoomCode(String roomCode);
+    Optional<Room> findOpenRoomByRoomCode(String roomCode);
 
-  boolean existsOpenRoomByMemberId(Long memberId);
+    boolean existsOpenRoomByMemberId(Long memberId);
 }

--- a/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepository.java
@@ -1,7 +1,12 @@
 package com.example.wini.domain.room.repository;
 
+import com.example.wini.domain.room.entity.Room;
 import java.util.Optional;
 
 public interface RoomCustomRepository {
-    Optional<Long> findOpenRoomIdByMemberId(Long memberId);
+   Optional<Long> findOpenRoomIdByMemberId(Long memberId);
+
+  Optional<Room> findOpenRoomByRoomCode(String roomCode);
+
+  boolean existsOpenRoomByMemberId(Long memberId);
 }

--- a/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepositoryImpl.java
@@ -16,32 +16,31 @@ public class RoomCustomRepositoryImpl implements RoomCustomRepository {
     @Override
     public Optional<Long> findOpenRoomIdByMemberId(Long memberId) {
         return Optional.ofNullable(queryFactory
-            .select(room.id)
-            .from(room)
-            .join(memberRoom)
-            .on(memberRoom.room.id.eq(room.id))
-            .where(memberRoom.member.id.eq(memberId).and(room.isClosed.isFalse()))
-            .fetchOne());
-    }
-
-      @Override
-      public Optional<Room> findOpenRoomByRoomCode(String roomCode) {
-        return Optional.ofNullable(
-            queryFactory
-                .selectFrom(room)
-                .where(room.roomCode.eq(roomCode).and(room.isClosed.isFalse()))
-                .fetchOne());
-      }
-
-      @Override
-      public boolean existsOpenRoomByMemberId(Long memberId) {
-        return queryFactory
-                .selectOne()
+                .select(room.id)
                 .from(room)
                 .join(memberRoom)
                 .on(memberRoom.room.id.eq(room.id))
                 .where(memberRoom.member.id.eq(memberId).and(room.isClosed.isFalse()))
-                .fetchFirst()
-            != null;
-      }
+                .fetchOne());
+    }
+
+    @Override
+    public Optional<Room> findOpenRoomByRoomCode(String roomCode) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(room)
+                .where(room.roomCode.eq(roomCode).and(room.isClosed.isFalse()))
+                .fetchOne());
+    }
+
+    @Override
+    public boolean existsOpenRoomByMemberId(Long memberId) {
+        return queryFactory
+                        .selectOne()
+                        .from(room)
+                        .join(memberRoom)
+                        .on(memberRoom.room.id.eq(room.id))
+                        .where(memberRoom.member.id.eq(memberId).and(room.isClosed.isFalse()))
+                        .fetchFirst()
+                != null;
+    }
 }

--- a/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.example.wini.domain.room.repository;
 import static com.example.wini.domain.room.entity.QMemberRoom.memberRoom;
 import static com.example.wini.domain.room.entity.QRoom.room;
 
+import com.example.wini.domain.room.entity.Room;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -15,11 +16,32 @@ public class RoomCustomRepositoryImpl implements RoomCustomRepository {
     @Override
     public Optional<Long> findOpenRoomIdByMemberId(Long memberId) {
         return Optional.ofNullable(queryFactory
-                .select(room.id)
+            .select(room.id)
+            .from(room)
+            .join(memberRoom)
+            .on(memberRoom.room.id.eq(room.id))
+            .where(memberRoom.member.id.eq(memberId).and(room.isClosed.isFalse()))
+            .fetchOne());
+    }
+
+      @Override
+      public Optional<Room> findOpenRoomByRoomCode(String roomCode) {
+        return Optional.ofNullable(
+            queryFactory
+                .selectFrom(room)
+                .where(room.roomCode.eq(roomCode).and(room.isClosed.isFalse()))
+                .fetchOne());
+      }
+
+      @Override
+      public boolean existsOpenRoomByMemberId(Long memberId) {
+        return queryFactory
+                .selectOne()
                 .from(room)
                 .join(memberRoom)
                 .on(memberRoom.room.id.eq(room.id))
                 .where(memberRoom.member.id.eq(memberId).and(room.isClosed.isFalse()))
-                .fetchOne());
-    }
+                .fetchFirst()
+            != null;
+      }
 }

--- a/src/main/java/com/example/wini/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/wini/domain/room/service/RoomService.java
@@ -1,5 +1,6 @@
 package com.example.wini.domain.room.service;
 
+import static com.example.wini.global.error.exception.ErrorCode.ALREADY_JOIN_ROOM;
 import static com.example.wini.global.error.exception.ErrorCode.MEMBER_NOT_FOUND;
 
 import com.example.wini.domain.member.domain.Member;
@@ -58,5 +59,12 @@ public class RoomService {
             codeBuilder.append(charSet.charAt(index));
         }
         return codeBuilder.toString();
+    }
+
+    private void validateMemberCanJoinRoom(Long memberId) {
+        boolean isAlreadyJoined = roomRepository.existsOpenRoomByMemberId(memberId);
+        if (isAlreadyJoined) {
+            throw new CustomException(ALREADY_JOIN_ROOM);
+        }
     }
 }

--- a/src/main/java/com/example/wini/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/wini/domain/room/service/RoomService.java
@@ -33,6 +33,7 @@ public class RoomService {
     @Transactional
     public RoomResponse createRoom(Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+        validateMemberCanJoinRoom(memberId);
 
         String roomCode = generateUniqueRoomCode();
 

--- a/src/main/java/com/example/wini/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/wini/domain/room/service/RoomService.java
@@ -68,15 +68,11 @@ public class RoomService {
 
     @Transactional
     public RoomResponse joinRoom(Long memberId, RoomJoinRequest request) {
-        Member member =
-            memberRepository
-                .findById(memberId)
-                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
         validateMemberCanJoinRoom(memberId);
 
-        Room room =
-            roomRepository
+        Room room = roomRepository
                 .findOpenRoomByRoomCode(request.roomCode())
                 .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
 
@@ -95,7 +91,7 @@ public class RoomService {
         }
     }
 
-   private void validateRoomCapacity(Room room) {
+    private void validateRoomCapacity(Room room) {
         long memberCount = memberRoomRepository.countMembersByRoomId(room.getId());
         if (memberCount >= ROOM_MEMBER_MAX_COUNT) {
             throw new CustomException(ROOM_IS_FULL);

--- a/src/main/java/com/example/wini/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/wini/domain/room/service/RoomService.java
@@ -3,9 +3,11 @@ package com.example.wini.domain.room.service;
 import static com.example.wini.global.error.exception.ErrorCode.ALREADY_JOIN_ROOM;
 import static com.example.wini.global.error.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static com.example.wini.global.error.exception.ErrorCode.ROOM_IS_FULL;
+import static com.example.wini.global.error.exception.ErrorCode.ROOM_NOT_FOUND;
 
 import com.example.wini.domain.member.domain.Member;
 import com.example.wini.domain.member.repository.MemberRepository;
+import com.example.wini.domain.room.dto.request.RoomJoinRequest;
 import com.example.wini.domain.room.dto.response.RoomResponse;
 import com.example.wini.domain.room.entity.MemberRoom;
 import com.example.wini.domain.room.entity.Room;
@@ -61,6 +63,28 @@ public class RoomService {
             codeBuilder.append(charSet.charAt(index));
         }
         return codeBuilder.toString();
+    }
+
+    @Transactional
+    public RoomResponse joinRoom(Long memberId, RoomJoinRequest request) {
+        Member member =
+            memberRepository
+                .findById(memberId)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        validateMemberCanJoinRoom(memberId);
+
+        Room room =
+            roomRepository
+                .findOpenRoomByRoomCode(request.roomCode())
+                .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
+
+        validateRoomCapacity(room);
+
+        MemberRoom memberRoom = MemberRoom.create(member, room);
+        memberRoomRepository.save(memberRoom);
+
+        return RoomResponse.from(room);
     }
 
     private void validateMemberCanJoinRoom(Long memberId) {

--- a/src/main/java/com/example/wini/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/wini/domain/room/service/RoomService.java
@@ -1,5 +1,8 @@
 package com.example.wini.domain.room.service;
 
+import static com.example.wini.global.common.constant.RoomConstants.ROOM_CODE_CHAR_SET;
+import static com.example.wini.global.common.constant.RoomConstants.ROOM_CODE_LENGTH;
+import static com.example.wini.global.common.constant.RoomConstants.ROOM_MEMBER_MAX_COUNT;
 import static com.example.wini.global.error.exception.ErrorCode.ALREADY_JOIN_ROOM;
 import static com.example.wini.global.error.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static com.example.wini.global.error.exception.ErrorCode.ROOM_IS_FULL;
@@ -22,9 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class RoomService {
-
-    private static final Integer ROOM_CODE_LENGTH = 7;
-    private static final Integer ROOM_MEMBER_MAX_COUNT = 2;
 
     private final MemberRepository memberRepository;
     private final RoomRepository roomRepository;
@@ -55,7 +55,7 @@ public class RoomService {
     }
 
     private String generateRoomCode() {
-        String charSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        String charSet = ROOM_CODE_CHAR_SET;
         SecureRandom random = new SecureRandom();
         StringBuilder codeBuilder = new StringBuilder(ROOM_CODE_LENGTH);
 

--- a/src/main/java/com/example/wini/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/wini/domain/room/service/RoomService.java
@@ -2,6 +2,7 @@ package com.example.wini.domain.room.service;
 
 import static com.example.wini.global.error.exception.ErrorCode.ALREADY_JOIN_ROOM;
 import static com.example.wini.global.error.exception.ErrorCode.MEMBER_NOT_FOUND;
+import static com.example.wini.global.error.exception.ErrorCode.ROOM_IS_FULL;
 
 import com.example.wini.domain.member.domain.Member;
 import com.example.wini.domain.member.repository.MemberRepository;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class RoomService {
 
     private static final Integer ROOM_CODE_LENGTH = 7;
+    private static final Integer ROOM_MEMBER_MAX_COUNT = 2;
 
     private final MemberRepository memberRepository;
     private final RoomRepository roomRepository;
@@ -65,6 +67,13 @@ public class RoomService {
         boolean isAlreadyJoined = roomRepository.existsOpenRoomByMemberId(memberId);
         if (isAlreadyJoined) {
             throw new CustomException(ALREADY_JOIN_ROOM);
+        }
+    }
+
+   private void validateRoomCapacity(Room room) {
+        long memberCount = memberRoomRepository.countMembersByRoomId(room.getId());
+        if (memberCount >= ROOM_MEMBER_MAX_COUNT) {
+            throw new CustomException(ROOM_IS_FULL);
         }
     }
 }

--- a/src/main/java/com/example/wini/global/common/constant/RoomConstants.java
+++ b/src/main/java/com/example/wini/global/common/constant/RoomConstants.java
@@ -2,9 +2,9 @@ package com.example.wini.global.common.constant;
 
 public class RoomConstants {
 
-  public static final int ROOM_CODE_LENGTH = 7;
-  public static final int ROOM_MEMBER_MAX_COUNT = 2;
-  public static final String ROOM_CODE_CHAR_SET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    public static final int ROOM_CODE_LENGTH = 7;
+    public static final int ROOM_MEMBER_MAX_COUNT = 2;
+    public static final String ROOM_CODE_CHAR_SET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
-  private RoomConstants() {}
+    private RoomConstants() {}
 }

--- a/src/main/java/com/example/wini/global/common/constant/RoomConstants.java
+++ b/src/main/java/com/example/wini/global/common/constant/RoomConstants.java
@@ -1,0 +1,10 @@
+package com.example.wini.global.common.constant;
+
+public class RoomConstants {
+
+  public static final int ROOM_CODE_LENGTH = 7;
+  public static final int ROOM_MEMBER_MAX_COUNT = 2;
+  public static final String ROOM_CODE_CHAR_SET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+  private RoomConstants() {}
+}

--- a/src/main/java/com/example/wini/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/example/wini/global/config/JpaAuditingConfig.java
@@ -1,0 +1,18 @@
+package com.example.wini.global.config;
+
+import java.util.Optional;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+
+  @Bean
+  public AuditorAware<Long> auditorAware() {
+    // TODO: 인증인가 구현하면 여기도 바꾸기
+    return () -> Optional.of(1L);
+  }
+}

--- a/src/main/java/com/example/wini/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/example/wini/global/config/JpaAuditingConfig.java
@@ -10,9 +10,9 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @Configuration
 public class JpaAuditingConfig {
 
-  @Bean
-  public AuditorAware<Long> auditorAware() {
-    // TODO: 인증인가 구현하면 여기도 바꾸기
-    return () -> Optional.of(1L);
-  }
+    @Bean
+    public AuditorAware<Long> auditorAware() {
+        // TODO: 인증인가 구현하면 여기도 바꾸기
+        return () -> Optional.of(1L);
+    }
 }

--- a/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
@@ -28,6 +28,8 @@ public enum ErrorCode {
 
     // Room
     ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 방입니다."),
+    ALREADY_JOIN_ROOM(HttpStatus.BAD_REQUEST, "이미 방에 속해있습니다."),
+    ROOM_IS_FULL(HttpStatus.BAD_REQUEST, "방의 정원이 가득 찼습니다."),
 
     // Note
     NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 마음쪽지입니다."),

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: "dev"
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 🌱 관련 이슈
- close #20 

## 📌 작업 내용 및 특이사항
- 초대코드 입력(방 참가) API 구현
- 방 입장 조건 검증 로직 구현 
  - 이미 참여 중인 방이 있으면 예외처리
  - 방 최대 인원(현 2명)을 초과하면 예외처리
- 방 생성 시 이미 참여 중인 방이 있는기 검증하는 메서드 추가
- DDL 옵션 update로 변경
- JPA Auditing 설정
- 회원 조회 시 상태가 없어도 조회 성공하도록 leftjoin으로 수정

## 📝 참고사항
- BaseEntity가 정상적으로 작동하지 않아 Jpa Auditing 설정을 추가했습니다. 

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 초대코드 입력으로 방에 합류하는 기능 추가(POST /rooms/join). 성공 시 방 정보 반환.
  * 합류 요청 DTO 및 방 코드/최대인원 관련 상수 도입.

* **Bug Fixes / Behavior**
  * 이미 방에 속한 사용자, 존재하지 않는 방 코드, 방 정원 초과에 대한 명확한 오류 처리 추가.
  * 멤버-방 관련 인원 수 집계 및 열려있는 방 조회/검증 로직 강화.
  * 일부 조회 쿼리에서 회원 상태가 없어도 결과 반환되도록 조인 방식 변경.

* **Documentation**
  * 신규 엔드포인트에 API 메타데이터(설명/요약) 추가.

* **Chores**
  * JPA 감사 기능 활성화(임시 감사자 ID 설정).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->