### PR TITLE
feat: 홈화면 통계 조회

### DIFF
--- a/src/main/java/com/example/wini/domain/log/controller/LogController.java
+++ b/src/main/java/com/example/wini/domain/log/controller/LogController.java
@@ -1,0 +1,25 @@
+package com.example.wini.domain.log.controller;
+
+import com.example.wini.domain.log.dto.response.LogSimpleResponse;
+import com.example.wini.domain.log.service.LogService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/log")
+@Tag(name = "4. 통계", description = "통계 관련 API")
+@RequiredArgsConstructor
+public class LogController {
+
+    private final LogService logService;
+
+    @GetMapping("/simple")
+    @Operation(summary = "홈 화면 통계 조회", description = "홈 화면에 들어가는 통계 결과를 반환합니다.")
+    public LogSimpleResponse getSimpleLog() {
+        return logService.generateSimpleLog();
+    }
+}

--- a/src/main/java/com/example/wini/domain/log/dto/response/LogSimpleResponse.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/LogSimpleResponse.java
@@ -1,0 +1,9 @@
+package com.example.wini.domain.log.dto.response;
+
+import java.time.LocalDateTime;
+
+public record LogSimpleResponse(long notesSentThisWeek, long notesReceivedThisWeek, LocalDateTime roomJoinedAt) {
+    public static LogSimpleResponse of(long notesSentThisWeek, long notesReceivedThisWeek, LocalDateTime roomJoinedAt) {
+        return new LogSimpleResponse(notesSentThisWeek, notesReceivedThisWeek, roomJoinedAt);
+    }
+}

--- a/src/main/java/com/example/wini/domain/log/service/LogService.java
+++ b/src/main/java/com/example/wini/domain/log/service/LogService.java
@@ -25,7 +25,7 @@ public class LogService {
         // TODO : 인가받은 사용자의 노트로 필터링 필요
         Long notesSentThisWeek = noteRepository.countNotesSentThisWeekByMemberId(1L);
         Long notesReceivedThisWeek = noteRepository.countNotesReceivedThisWeekByMemberId(1L);
-        Room room = roomRepository.findOpenRoomIdByMemberId(1L).orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
+        Room room = roomRepository.findOpenRoomByMemberId(1L).orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
 
         return LogSimpleResponse.of(notesSentThisWeek, notesReceivedThisWeek, room.getCreatedAt());
     }

--- a/src/main/java/com/example/wini/domain/log/service/LogService.java
+++ b/src/main/java/com/example/wini/domain/log/service/LogService.java
@@ -1,0 +1,32 @@
+package com.example.wini.domain.log.service;
+
+import static com.example.wini.global.error.exception.ErrorCode.*;
+
+import com.example.wini.domain.log.dto.response.LogSimpleResponse;
+import com.example.wini.domain.note.repository.NoteRepository;
+import com.example.wini.domain.room.entity.Room;
+import com.example.wini.domain.room.repository.RoomRepository;
+import com.example.wini.global.error.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LogService {
+
+    private final NoteRepository noteRepository;
+    private final RoomRepository roomRepository;
+
+    @Transactional(readOnly = true)
+    public LogSimpleResponse generateSimpleLog() {
+        // TODO : 인가받은 사용자의 노트로 필터링 필요
+        Long notesSentThisWeek = noteRepository.countNotesSentThisWeekByMemberId(1L);
+        Long notesReceivedThisWeek = noteRepository.countNotesReceivedThisWeekByMemberId(1L);
+        Room room = roomRepository.findOpenRoomIdByMemberId(1L).orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
+
+        return LogSimpleResponse.of(notesSentThisWeek, notesReceivedThisWeek, room.getCreatedAt());
+    }
+}

--- a/src/main/java/com/example/wini/domain/note/domain/Note.java
+++ b/src/main/java/com/example/wini/domain/note/domain/Note.java
@@ -17,12 +17,15 @@ public class Note extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // TODO : 인증인가 후 MemberRoom 연결
+    // TODO : 인증인가 후 멤버 연결하기
     @Column(nullable = false)
-    private Long memberRoomSenderId;
+    private Long senderId;
 
     @Column(nullable = false)
-    private Long memberRoomReceiverId;
+    private Long receiverId;
+
+    @Column(nullable = false)
+    private Long roomId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "emotion_id")
@@ -55,16 +58,18 @@ public class Note extends BaseEntity {
 
     @Builder(access = AccessLevel.PRIVATE)
     private Note(
-            Long memberRoomSenderId,
-            Long memberRoomReceiverId,
+            Long senderId,
+            Long receiverId,
+            Long roomId,
             Emotion emotion,
             Action action,
             Situation situation,
             Promise promise,
             Closing closing,
             int sequence) {
-        this.memberRoomSenderId = memberRoomSenderId;
-        this.memberRoomReceiverId = memberRoomReceiverId;
+        this.senderId = senderId;
+        this.receiverId = receiverId;
+        this.roomId = roomId;
         this.emotion = emotion;
         this.action = action;
         this.situation = situation;
@@ -76,8 +81,9 @@ public class Note extends BaseEntity {
     }
 
     public static Note create(
-            Long memberRoomSenderId,
-            Long memberRoomReceiverId,
+            Long senderId,
+            Long receiverId,
+            Long roomId,
             Emotion emotion,
             Action action,
             Situation situation,
@@ -85,8 +91,9 @@ public class Note extends BaseEntity {
             Closing closing,
             int sequence) {
         return Note.builder()
-                .memberRoomSenderId(memberRoomSenderId)
-                .memberRoomReceiverId(memberRoomReceiverId)
+                .senderId(senderId)
+                .receiverId(receiverId)
+                .roomId(roomId)
                 .emotion(emotion)
                 .action(action)
                 .situation(situation)

--- a/src/main/java/com/example/wini/domain/note/dto/response/NoteResponse.java
+++ b/src/main/java/com/example/wini/domain/note/dto/response/NoteResponse.java
@@ -6,8 +6,9 @@ import java.time.LocalDateTime;
 
 public record NoteResponse(
         Long id,
-        Long memberRoomSenderId,
-        Long memberRoomReceiverId,
+        Long senderId,
+        Long receiverId,
+        Long roomId,
         EmotionResponse emotion,
         ActionResponse action,
         SituationResponse situation,
@@ -20,8 +21,9 @@ public record NoteResponse(
     public static NoteResponse from(Note note) {
         return new NoteResponse(
                 note.getId(),
-                note.getMemberRoomSenderId(),
-                note.getMemberRoomReceiverId(),
+                note.getSenderId(),
+                note.getReceiverId(),
+                note.getRoomId(),
                 EmotionResponse.from(note.getEmotion()),
                 ActionResponse.from(note.getAction()),
                 SituationResponse.from(note.getSituation()),

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
@@ -12,4 +12,8 @@ public interface NoteCustomRepository {
     List<Note> findSavedNotes();
 
     Long countTodayNotes();
+
+    Long countNotesSentThisWeekByMemberId(Long memberId);
+
+    Long countNotesReceivedThisWeekByMemberId(Long memberId);
 }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -5,8 +5,10 @@ import static com.example.wini.domain.note.domain.QNote.note;
 import com.example.wini.domain.note.domain.Note;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +51,24 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         return queryFactory.select(note.count()).from(note).where(isToday()).fetchFirst();
     }
 
+    @Override
+    public Long countNotesSentThisWeekByMemberId(Long memberId) {
+        return queryFactory
+                .select(note.count())
+                .from(note)
+                .where(isThisWeek().and(isSender(memberId)))
+                .fetchFirst();
+    }
+
+    @Override
+    public Long countNotesReceivedThisWeekByMemberId(Long memberId) {
+        return queryFactory
+                .select(note.count())
+                .from(note)
+                .where(isThisWeek().and(isReceiver(memberId)))
+                .fetchFirst();
+    }
+
     private BooleanExpression isLatest() {
         return note.createdAt.after(LocalDateTime.now().minusHours(24));
     }
@@ -57,5 +77,22 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         LocalDateTime start = LocalDate.now().atStartOfDay();
         LocalDateTime end = LocalDate.now().plusDays(1).atStartOfDay();
         return note.createdAt.goe(start).and(note.createdAt.lt(end));
+    }
+
+    private BooleanExpression isThisWeek() {
+        LocalDateTime startOfWeek = LocalDate.now()
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+                .atStartOfDay();
+        LocalDateTime startOfNextWeek =
+                LocalDate.now().with(TemporalAdjusters.next(DayOfWeek.MONDAY)).atStartOfDay();
+        return note.createdAt.goe(startOfWeek).and(note.createdAt.lt(startOfNextWeek));
+    }
+
+    private BooleanExpression isSender(Long memberId) {
+        return note.senderId.eq(memberId);
+    }
+
+    private BooleanExpression isReceiver(Long memberId) {
+        return note.receiverId.eq(memberId);
     }
 }

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -85,7 +85,7 @@ public class NoteService {
                 .orElseThrow(() -> new CustomException(CLOSING_NOT_FOUND));
         int nextSequence = getNextSequence();
 
-        return Note.create(1L, 2L, emotion, action, situation, promise, closing, nextSequence);
+        return Note.create(1L, 2L, 1L, emotion, action, situation, promise, closing, nextSequence);
     }
 
     private int getNextSequence() {

--- a/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepository.java
@@ -4,7 +4,7 @@ import com.example.wini.domain.room.entity.Room;
 import java.util.Optional;
 
 public interface RoomCustomRepository {
-    Optional<Long> findOpenRoomIdByMemberId(Long memberId);
+    Optional<Room> findOpenRoomIdByMemberId(Long memberId);
 
     Optional<Room> findOpenRoomByRoomCode(String roomCode);
 

--- a/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepository.java
@@ -4,7 +4,7 @@ import com.example.wini.domain.room.entity.Room;
 import java.util.Optional;
 
 public interface RoomCustomRepository {
-    Optional<Room> findOpenRoomIdByMemberId(Long memberId);
+    Optional<Room> findOpenRoomByMemberId(Long memberId);
 
     Optional<Room> findOpenRoomByRoomCode(String roomCode);
 

--- a/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepositoryImpl.java
@@ -14,10 +14,9 @@ public class RoomCustomRepositoryImpl implements RoomCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Optional<Long> findOpenRoomIdByMemberId(Long memberId) {
+    public Optional<Room> findOpenRoomIdByMemberId(Long memberId) {
         return Optional.ofNullable(queryFactory
-                .select(room.id)
-                .from(room)
+                .selectFrom(room)
                 .join(memberRoom)
                 .on(memberRoom.room.id.eq(room.id))
                 .where(memberRoom.member.id.eq(memberId).and(room.isClosed.isFalse()))

--- a/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/room/repository/RoomCustomRepositoryImpl.java
@@ -14,7 +14,7 @@ public class RoomCustomRepositoryImpl implements RoomCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Optional<Room> findOpenRoomIdByMemberId(Long memberId) {
+    public Optional<Room> findOpenRoomByMemberId(Long memberId) {
         return Optional.ofNullable(queryFactory
                 .selectFrom(room)
                 .join(memberRoom)


### PR DESCRIPTION
## 🌱 관련 이슈
- close #40

## 📌 작업 내용 및 특이사항
- 홈화면 통계 조회 API 구현
- 쪽지 엔티티 필드 수정
  - `memberRoomId`에서 `memberId`로 변경
  - `roomId` 추가

## 📝 참고사항
- 사용자가 현재 속해있는 방 로직을 `selectFrom()`을 사용하여 수정 후 서비스 로직에 사용했습니다.
- member와 room 연결은 인증인가 진행 후에 하겠습니다.
- 추후 통계 관련 API에 `roomId`로 필터링하는 쿼리 파라미터도 추가하면 좋을 것 같습니다. (여러 방에 대한 통계 자료가 쌓이는 경우)

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 홈 화면 통계 조회 API 추가: 이번 주 보낸/받은 쪽지 수와 방 참여일을 반환하는 간단 조회 엔드포인트 제공.
  - 주간 쪽지 집계 기능 추가: 사용자별 이번 주 보낸/받은 쪽지 수 집계 제공.

- Refactor
  - Note 및 응답 스키마 변경: 필드명이 senderId, receiverId, roomId로 정리되어 클라이언트 매핑 영향 있음.
  - 방 조회 API 반환 타입 개선: 열린 방 조회 시 엔티티 반환으로 사용성 향상.

- Documentation
  - OpenAPI 문서 및 통계 태그 추가로 API 탐색성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->