### PR TITLE
feat: 주간 통계 조회

### DIFF
--- a/src/main/java/com/example/wini/domain/log/controller/LogController.java
+++ b/src/main/java/com/example/wini/domain/log/controller/LogController.java
@@ -1,6 +1,6 @@
 package com.example.wini.domain.log.controller;
 
-import com.example.wini.domain.log.dto.response.LogSimpleResponse;
+import com.example.wini.domain.log.dto.response.StatisticsResponse;
 import com.example.wini.domain.log.service.LogService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,9 +17,9 @@ public class LogController {
 
     private final LogService logService;
 
-    @GetMapping("/simple")
-    @Operation(summary = "홈 화면 통계 조회", description = "홈 화면에 들어가는 통계 결과를 반환합니다.")
-    public LogSimpleResponse getSimpleLog() {
-        return logService.generateSimpleLog();
+    @GetMapping("/statistics")
+    @Operation(summary = "주간 통계 조회", description = "주간 통계 결과를 반환합니다.")
+    public StatisticsResponse getStatistics() {
+        return logService.getWeeklyStatistics();
     }
 }

--- a/src/main/java/com/example/wini/domain/log/dto/response/LogSimpleResponse.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/LogSimpleResponse.java
@@ -1,9 +1,0 @@
-package com.example.wini.domain.log.dto.response;
-
-import java.time.LocalDateTime;
-
-public record LogSimpleResponse(long notesSentThisWeek, long notesReceivedThisWeek, LocalDateTime roomJoinedAt) {
-    public static LogSimpleResponse of(long notesSentThisWeek, long notesReceivedThisWeek, LocalDateTime roomJoinedAt) {
-        return new LogSimpleResponse(notesSentThisWeek, notesReceivedThisWeek, roomJoinedAt);
-    }
-}

--- a/src/main/java/com/example/wini/domain/log/dto/response/StatisticsResponse.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/StatisticsResponse.java
@@ -1,0 +1,10 @@
+package com.example.wini.domain.log.dto.response;
+
+import java.time.LocalDateTime;
+
+public record StatisticsResponse(long notesSentThisWeek, long notesReceivedThisWeek, LocalDateTime roomJoinedAt) {
+    public static StatisticsResponse of(
+            long notesSentThisWeek, long notesReceivedThisWeek, LocalDateTime roomJoinedAt) {
+        return new StatisticsResponse(notesSentThisWeek, notesReceivedThisWeek, roomJoinedAt);
+    }
+}

--- a/src/main/java/com/example/wini/domain/log/service/LogService.java
+++ b/src/main/java/com/example/wini/domain/log/service/LogService.java
@@ -2,7 +2,7 @@ package com.example.wini.domain.log.service;
 
 import static com.example.wini.global.error.exception.ErrorCode.*;
 
-import com.example.wini.domain.log.dto.response.LogSimpleResponse;
+import com.example.wini.domain.log.dto.response.StatisticsResponse;
 import com.example.wini.domain.note.repository.NoteRepository;
 import com.example.wini.domain.room.entity.Room;
 import com.example.wini.domain.room.repository.RoomRepository;
@@ -21,12 +21,12 @@ public class LogService {
     private final RoomRepository roomRepository;
 
     @Transactional(readOnly = true)
-    public LogSimpleResponse generateSimpleLog() {
+    public StatisticsResponse getWeeklyStatistics() {
         // TODO : 인가받은 사용자의 노트로 필터링 필요
         Long notesSentThisWeek = noteRepository.countNotesSentThisWeekByMemberId(1L);
         Long notesReceivedThisWeek = noteRepository.countNotesReceivedThisWeekByMemberId(1L);
         Room room = roomRepository.findOpenRoomByMemberId(1L).orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
 
-        return LogSimpleResponse.of(notesSentThisWeek, notesReceivedThisWeek, room.getCreatedAt());
+        return StatisticsResponse.of(notesSentThisWeek, notesReceivedThisWeek, room.getCreatedAt());
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #41

## 📌 작업 내용 및 특이사항
- 주간 통계 조회 API 엔드포인트 변경
- 응답 dto 이름 수정

## 📝 참고사항
- 원래 통계 페이지에 들어갈 통계 조회 API를 따로 만들 예정이었으나, 반환하는 데이터가 같아 하나로 통합했습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 주간 통계 API를 추가했습니다: /statistics 경로에서 주간 보낸/받은 쪽지 수와 방 참여일을 제공합니다.

- 리팩터링
  - 기존 홈 요약 API(/simple)를 주간 통계 API(/statistics)로 대체했습니다. 클라이언트는 요청 경로를 /statistics로 변경해 주세요.
  - 응답 구조는 주간 보낸 쪽지 수, 주간 받은 쪽지 수, 방 참여일 정보를 포함합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->