### PR TITLE
feat: 카카오 로그인

### DIFF
--- a/.github/workflows/java_ci_build.yml
+++ b/.github/workflows/java_ci_build.yml
@@ -31,3 +31,13 @@ jobs:
 
       - name: Build with Gradle Wrapper
         run: ./gradlew build
+
+      - name: Upload test & problems reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            build/reports/tests/**         
+            build/test-results/**           
+            build/reports/problems/**

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'
@@ -55,6 +56,13 @@ dependencies {
 
     // firebase
     implementation 'com.google.firebase:firebase-admin:9.4.1'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
+
+    // rest client
+    implementation 'org.apache.httpcomponents.client5:httpclient5'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,10 @@ dependencies {
 
     // rest client
     implementation 'org.apache.httpcomponents.client5:httpclient5'
+
+    // cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation "com.github.ben-manes.caffeine:caffeine"
 }
 
 test {

--- a/src/main/java/com/example/wini/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/wini/domain/auth/controller/AuthController.java
@@ -10,6 +10,8 @@ import com.example.wini.global.security.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,14 +31,15 @@ public class AuthController {
 
     @GetMapping("/login/kakao")
     @SecurityRequirements(value = {})
-    @Operation(summary = "카카오 로그인 페이지", description = "카카오 로그인 페이지 주소를 반환합니다.")
-    public String kakaoLoginForm() {
-        return authService.getKakaoLoginForm();
+    @Operation(summary = "카카오 로그인", description = "카카오 로그인 페이지로 리다이렉트 됩니다.")
+    public void kakaoLoginForm(HttpServletResponse response) throws IOException {
+        String redirectUrl = authService.getKakaoLoginForm();
+        response.sendRedirect(redirectUrl);
     }
 
     @GetMapping("/kakao/callback")
     @SecurityRequirements(value = {})
-    @Operation(summary = "카카오 로그인", description = "토큰을 반환합니다.")
+    @Operation(summary = "카카오 로그인 콜백", description = "카카오 로그인 후 토큰을 반환합니다.")
     public TokenResponse kakaoLogin(@RequestParam("code") String authCode) {
         return authService.kakaoLogin(authCode);
     }

--- a/src/main/java/com/example/wini/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/wini/domain/auth/controller/AuthController.java
@@ -5,8 +5,6 @@ import static com.example.wini.global.common.constant.SecurityConstants.BEARER_T
 import com.example.wini.domain.auth.dto.response.TokenResponse;
 import com.example.wini.domain.auth.service.AuthService;
 import com.example.wini.domain.auth.service.TokenService;
-import com.example.wini.domain.common.annotation.Auth;
-import com.example.wini.global.security.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -46,8 +44,8 @@ public class AuthController {
 
     @PostMapping("logout")
     @Operation(summary = "로그아웃", description = "토큰을 무효화시킵니다.")
-    public void logout(@RequestHeader("Authorization") String header, @Auth AuthMember authMember) {
+    public void logout(@RequestHeader("Authorization") String header) {
         String accessToken = header.substring(BEARER_TOKEN_PREFIX.length());
-        tokenService.deleteToken(accessToken, authMember);
+        tokenService.deleteToken(accessToken);
     }
 }

--- a/src/main/java/com/example/wini/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/wini/domain/auth/controller/AuthController.java
@@ -1,11 +1,18 @@
 package com.example.wini.domain.auth.controller;
 
+import static com.example.wini.global.common.constant.SecurityConstants.BEARER_TOKEN_PREFIX;
+
 import com.example.wini.domain.auth.dto.response.TokenResponse;
 import com.example.wini.domain.auth.service.AuthService;
+import com.example.wini.domain.auth.service.TokenService;
+import com.example.wini.domain.common.annotation.Auth;
+import com.example.wini.global.security.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final TokenService tokenService;
 
     @GetMapping("/login/kakao")
     @Operation(summary = "카카오 로그인 페이지", description = "카카오 로그인 페이지 주소를 반환합니다.")
@@ -28,5 +36,12 @@ public class AuthController {
     @Operation(summary = "카카오 로그인", description = "토큰을 반환합니다.")
     public TokenResponse kakaoLogin(@RequestParam("code") String authCode) {
         return authService.kakaoLogin(authCode);
+    }
+
+    @PostMapping("logout")
+    @Operation(summary = "로그아웃", description = "토큰을 무효화시킵니다.")
+    public void logout(@RequestHeader("Authorization") String header, @Auth AuthMember authMember) {
+        String accessToken = header.substring(BEARER_TOKEN_PREFIX.length());
+        tokenService.deleteToken(accessToken, authMember);
     }
 }

--- a/src/main/java/com/example/wini/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/wini/domain/auth/controller/AuthController.java
@@ -1,0 +1,32 @@
+package com.example.wini.domain.auth.controller;
+
+import com.example.wini.domain.auth.dto.response.TokenResponse;
+import com.example.wini.domain.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@Tag(name = "8. 인증 인가", description = "인증인가 관련 API")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/login/kakao")
+    @Operation(summary = "카카오 로그인 페이지", description = "카카오 로그인 페이지 주소를 반환합니다.")
+    public String kakaoLoginForm() {
+        return authService.getKakaoLoginForm();
+    }
+
+    @GetMapping("/kakao/callback")
+    @Operation(summary = "카카오 로그인", description = "토큰을 반환합니다.")
+    public TokenResponse kakaoLogin(@RequestParam("code") String authCode) {
+        return authService.kakaoLogin(authCode);
+    }
+}

--- a/src/main/java/com/example/wini/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/wini/domain/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import com.example.wini.domain.auth.service.TokenService;
 import com.example.wini.domain.common.annotation.Auth;
 import com.example.wini.global.security.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,12 +28,14 @@ public class AuthController {
     private final TokenService tokenService;
 
     @GetMapping("/login/kakao")
+    @SecurityRequirements(value = {})
     @Operation(summary = "카카오 로그인 페이지", description = "카카오 로그인 페이지 주소를 반환합니다.")
     public String kakaoLoginForm() {
         return authService.getKakaoLoginForm();
     }
 
     @GetMapping("/kakao/callback")
+    @SecurityRequirements(value = {})
     @Operation(summary = "카카오 로그인", description = "토큰을 반환합니다.")
     public TokenResponse kakaoLogin(@RequestParam("code") String authCode) {
         return authService.kakaoLogin(authCode);

--- a/src/main/java/com/example/wini/domain/auth/controller/RefreshTokenController.java
+++ b/src/main/java/com/example/wini/domain/auth/controller/RefreshTokenController.java
@@ -1,7 +1,7 @@
 package com.example.wini.domain.auth.controller;
 
 import com.example.wini.domain.auth.dto.response.TokenResponse;
-import com.example.wini.domain.auth.service.TokenService;
+import com.example.wini.domain.auth.service.RefreshTokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -16,11 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class RefreshTokenController {
 
-    private final TokenService tokenService;
+    private final RefreshTokenService refreshTokenService;
 
     @PostMapping("/reissue")
     @Operation(summary = "토큰 재발급", description = "유효한 토큰을 반환합니다.")
     public TokenResponse reissueToken(@RequestHeader("Authorization") String refreshTokenHeader) {
-        return tokenService.reissueToken(refreshTokenHeader);
+        return refreshTokenService.reissueToken(refreshTokenHeader);
     }
 }

--- a/src/main/java/com/example/wini/domain/auth/controller/RefreshTokenController.java
+++ b/src/main/java/com/example/wini/domain/auth/controller/RefreshTokenController.java
@@ -1,7 +1,7 @@
 package com.example.wini.domain.auth.controller;
 
 import com.example.wini.domain.auth.dto.response.TokenResponse;
-import com.example.wini.domain.auth.service.RefreshTokenService;
+import com.example.wini.domain.auth.service.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -16,11 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class RefreshTokenController {
 
-    private final RefreshTokenService refreshTokenService;
+    private final TokenService tokenService;
 
     @PostMapping("/reissue")
     @Operation(summary = "토큰 재발급", description = "유효한 토큰을 반환합니다.")
     public TokenResponse reissueToken(@RequestHeader("Authorization") String refreshTokenHeader) {
-        return refreshTokenService.reissueToken(refreshTokenHeader);
+        return tokenService.reissueToken(refreshTokenHeader);
     }
 }

--- a/src/main/java/com/example/wini/domain/auth/controller/RefreshTokenController.java
+++ b/src/main/java/com/example/wini/domain/auth/controller/RefreshTokenController.java
@@ -1,0 +1,26 @@
+package com.example.wini.domain.auth.controller;
+
+import com.example.wini.domain.auth.dto.response.TokenResponse;
+import com.example.wini.domain.auth.service.RefreshTokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@Tag(name = "8. 인증 인가", description = "인증인가 관련 API")
+@RequiredArgsConstructor
+public class RefreshTokenController {
+
+    private final RefreshTokenService refreshTokenService;
+
+    @PostMapping("/reissue")
+    @Operation(summary = "토큰 재발급", description = "유효한 토큰을 반환합니다.")
+    public TokenResponse reissueToken(@RequestHeader("Authorization") String refreshTokenHeader) {
+        return refreshTokenService.reissueToken(refreshTokenHeader);
+    }
+}

--- a/src/main/java/com/example/wini/domain/auth/domain/RefreshToken.java
+++ b/src/main/java/com/example/wini/domain/auth/domain/RefreshToken.java
@@ -39,4 +39,8 @@ public class RefreshToken {
     public static RefreshToken create(Member member, String token) {
         return RefreshToken.builder().member(member).token(token).build();
     }
+
+    public void updateToken(String newToken) {
+        this.token = newToken;
+    }
 }

--- a/src/main/java/com/example/wini/domain/auth/domain/RefreshToken.java
+++ b/src/main/java/com/example/wini/domain/auth/domain/RefreshToken.java
@@ -1,0 +1,42 @@
+package com.example.wini.domain.auth.domain;
+
+import com.example.wini.domain.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String token;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private RefreshToken(Member member, String token) {
+        this.member = member;
+        this.token = token;
+    }
+
+    public static RefreshToken create(Member member, String token) {
+        return RefreshToken.builder().member(member).token(token).build();
+    }
+}

--- a/src/main/java/com/example/wini/domain/auth/dto/common/OauthMemberInfo.java
+++ b/src/main/java/com/example/wini/domain/auth/dto/common/OauthMemberInfo.java
@@ -1,0 +1,13 @@
+package com.example.wini.domain.auth.dto.common;
+
+import com.example.wini.infra.kakao.dto.KakaoUser;
+
+public record OauthMemberInfo(String providerId, String name, String imageUrl) {
+
+    public static OauthMemberInfo from(KakaoUser kakaoUser) {
+        return new OauthMemberInfo(
+                String.valueOf(kakaoUser.id()),
+                kakaoUser.kakaoAccount().profile().nickname(),
+                kakaoUser.kakaoAccount().profile().profileImageUrl());
+    }
+}

--- a/src/main/java/com/example/wini/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/example/wini/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,8 @@
+package com.example.wini.domain.auth.dto.response;
+
+public record TokenResponse(String accessToken, String refreshToken) {
+
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/example/wini/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/wini/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,6 @@
+package com.example.wini.domain.auth.repository;
+
+import com.example.wini.domain.auth.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {}

--- a/src/main/java/com/example/wini/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/wini/domain/auth/repository/RefreshTokenRepository.java
@@ -1,6 +1,10 @@
 package com.example.wini.domain.auth.repository;
 
 import com.example.wini.domain.auth.domain.RefreshToken;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {}
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+}

--- a/src/main/java/com/example/wini/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/wini/domain/auth/repository/RefreshTokenRepository.java
@@ -10,4 +10,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByToken(String token);
 
     void deleteByMember(Member member);
+
+    Optional<RefreshToken> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/example/wini/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/wini/domain/auth/repository/RefreshTokenRepository.java
@@ -1,10 +1,13 @@
 package com.example.wini.domain.auth.repository;
 
 import com.example.wini.domain.auth.domain.RefreshToken;
+import com.example.wini.domain.member.domain.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByToken(String token);
+
+    void deleteByMember(Member member);
 }

--- a/src/main/java/com/example/wini/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/AuthService.java
@@ -18,7 +18,7 @@ public class AuthService {
 
     private final KakaoClient kakaoClient;
     private final MemberRepository memberRepository;
-    private final RefreshTokenService refreshTokenService;
+    private final TokenService tokenService;
 
     @Transactional(readOnly = true)
     public String getKakaoLoginForm() {
@@ -37,6 +37,6 @@ public class AuthService {
             return memberRepository.save(newMember);
         });
 
-        return refreshTokenService.generateTokens(member);
+        return tokenService.generateTokens(member);
     }
 }

--- a/src/main/java/com/example/wini/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/AuthService.java
@@ -30,7 +30,8 @@ public class AuthService {
         String kakaoAccessToken = kakaoClient.getAccessToken(authCode);
         OauthMemberInfo oauthMemberInfo = kakaoClient.getMemberInfo(kakaoAccessToken);
 
-        Optional<Member> optionalMember = memberRepository.findByOauthId(oauthMemberInfo.providerId());
+        Optional<Member> optionalMember =
+                memberRepository.findByOauthIdAndOauthProvider(oauthMemberInfo.providerId(), KAKAO);
 
         Member member = optionalMember.orElseGet(() -> {
             Member newMember = Member.create(oauthMemberInfo, KAKAO);

--- a/src/main/java/com/example/wini/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/AuthService.java
@@ -37,6 +37,6 @@ public class AuthService {
             return memberRepository.save(newMember);
         });
 
-        return tokenService.generateTokens(member);
+        return tokenService.upsertTokens(member);
     }
 }

--- a/src/main/java/com/example/wini/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/AuthService.java
@@ -1,0 +1,42 @@
+package com.example.wini.domain.auth.service;
+
+import static com.example.wini.domain.member.domain.OauthProvider.KAKAO;
+
+import com.example.wini.domain.auth.dto.common.OauthMemberInfo;
+import com.example.wini.domain.auth.dto.response.TokenResponse;
+import com.example.wini.domain.member.domain.Member;
+import com.example.wini.domain.member.repository.MemberRepository;
+import com.example.wini.infra.kakao.client.KakaoClient;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoClient kakaoClient;
+    private final MemberRepository memberRepository;
+    private final RefreshTokenService refreshTokenService;
+
+    @Transactional(readOnly = true)
+    public String getKakaoLoginForm() {
+        return kakaoClient.getAuthorizationCodeUri();
+    }
+
+    @Transactional
+    public TokenResponse kakaoLogin(String authCode) {
+        String kakaoAccessToken = kakaoClient.getAccessToken(authCode);
+        OauthMemberInfo oauthMemberInfo = kakaoClient.getMemberInfo(kakaoAccessToken);
+
+        Optional<Member> optionalMember = memberRepository.findByOauthId(oauthMemberInfo.providerId());
+
+        Member member = optionalMember.orElseGet(() -> {
+            Member newMember = Member.create(oauthMemberInfo, KAKAO);
+            return memberRepository.save(newMember);
+        });
+
+        return refreshTokenService.generateToken(member);
+    }
+}

--- a/src/main/java/com/example/wini/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/AuthService.java
@@ -37,6 +37,6 @@ public class AuthService {
             return memberRepository.save(newMember);
         });
 
-        return refreshTokenService.generateToken(member);
+        return refreshTokenService.generateTokens(member);
     }
 }

--- a/src/main/java/com/example/wini/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/RefreshTokenService.java
@@ -1,9 +1,15 @@
 package com.example.wini.domain.auth.service;
 
+import static com.example.wini.global.common.constant.SecurityConstants.REFRESH_TOKEN;
+import static com.example.wini.global.error.exception.ErrorCode.INVALID_REFRESH_TOKEN;
+import static com.example.wini.global.error.exception.ErrorCode.MEMBER_NOT_FOUND;
+
 import com.example.wini.domain.auth.domain.RefreshToken;
 import com.example.wini.domain.auth.dto.response.TokenResponse;
 import com.example.wini.domain.auth.repository.RefreshTokenRepository;
 import com.example.wini.domain.member.domain.Member;
+import com.example.wini.domain.member.repository.MemberRepository;
+import com.example.wini.global.error.exception.CustomException;
 import com.example.wini.global.security.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,16 +19,51 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class RefreshTokenService {
 
+    private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
 
     @Transactional
-    public TokenResponse generateToken(Member member) {
+    public TokenResponse generateTokens(Member member) {
+        String accessToken = jwtProvider.generateAccessToken(member);
+        String refreshToken = jwtProvider.generateRefreshToken(member);
+
+        RefreshToken newRefreshTokenEntity = RefreshToken.create(member, jwtProvider.substringToken(refreshToken));
+        refreshTokenRepository.save(newRefreshTokenEntity);
+
+        return TokenResponse.of(accessToken, refreshToken);
+    }
+
+    @Transactional
+    public TokenResponse reissueToken(String refreshTokenHeader) {
+        String refreshToken = validateRefreshToken(refreshTokenHeader);
+
+        return updateAndGenerateTokens(refreshToken);
+    }
+
+    private String validateRefreshToken(String refreshTokenHeader) {
+        String refreshToken = jwtProvider.substringToken(refreshTokenHeader);
+
+        if (!jwtProvider.validToken(refreshToken, REFRESH_TOKEN)) {
+            throw new CustomException(INVALID_REFRESH_TOKEN);
+        }
+        return refreshToken;
+    }
+
+    private TokenResponse updateAndGenerateTokens(String refreshToken) {
+        Long userId = jwtProvider.getMemberId(refreshToken, REFRESH_TOKEN);
+
+        Member member = memberRepository.findById(userId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        RefreshToken storedRefreshToken = refreshTokenRepository
+                .findByToken(refreshToken)
+                .orElseThrow(() -> new CustomException(INVALID_REFRESH_TOKEN));
+
         String newAccessToken = jwtProvider.generateAccessToken(member);
         String newRefreshToken = jwtProvider.generateRefreshToken(member);
 
-        RefreshToken refreshToken = RefreshToken.create(member, jwtProvider.substringToken(newRefreshToken));
-        refreshTokenRepository.save(refreshToken);
+        storedRefreshToken.updateToken(newRefreshToken);
+        refreshTokenRepository.save(storedRefreshToken);
 
         return TokenResponse.of(newAccessToken, newRefreshToken);
     }

--- a/src/main/java/com/example/wini/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/RefreshTokenService.java
@@ -1,0 +1,44 @@
+package com.example.wini.domain.auth.service;
+
+import static com.example.wini.global.common.constant.SecurityConstants.REFRESH_TOKEN;
+import static com.example.wini.global.error.exception.ErrorCode.INVALID_REFRESH_TOKEN;
+import static com.example.wini.global.error.exception.ErrorCode.MEMBER_NOT_FOUND;
+
+import com.example.wini.domain.auth.dto.response.TokenResponse;
+import com.example.wini.domain.auth.repository.RefreshTokenRepository;
+import com.example.wini.domain.member.domain.Member;
+import com.example.wini.domain.member.repository.MemberRepository;
+import com.example.wini.global.error.exception.CustomException;
+import com.example.wini.global.security.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProvider jwtProvider;
+    private final TokenService tokenService;
+
+    @Transactional
+    public TokenResponse reissueToken(String refreshTokenHeader) {
+        String refreshToken = jwtProvider.substringToken(refreshTokenHeader);
+        validateRefreshToken(refreshToken);
+
+        Long userId = jwtProvider.getMemberId(refreshToken, REFRESH_TOKEN);
+
+        Member member = memberRepository.findById(userId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+        refreshTokenRepository.findByToken(refreshToken).orElseThrow(() -> new CustomException(INVALID_REFRESH_TOKEN));
+
+        return tokenService.upsertTokens(member);
+    }
+
+    private void validateRefreshToken(String refreshToken) {
+        if (!jwtProvider.validToken(refreshToken, REFRESH_TOKEN)) {
+            throw new CustomException(INVALID_REFRESH_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/example/wini/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/RefreshTokenService.java
@@ -28,9 +28,9 @@ public class RefreshTokenService {
         String refreshToken = jwtProvider.substringToken(refreshTokenHeader);
         validateRefreshToken(refreshToken);
 
-        Long userId = jwtProvider.getMemberId(refreshToken, REFRESH_TOKEN);
+        Long memberId = jwtProvider.getMemberId(refreshToken, REFRESH_TOKEN);
 
-        Member member = memberRepository.findById(userId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
         refreshTokenRepository.findByToken(refreshToken).orElseThrow(() -> new CustomException(INVALID_REFRESH_TOKEN));
 
         return tokenService.upsertTokens(member);

--- a/src/main/java/com/example/wini/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/RefreshTokenService.java
@@ -1,0 +1,29 @@
+package com.example.wini.domain.auth.service;
+
+import com.example.wini.domain.auth.domain.RefreshToken;
+import com.example.wini.domain.auth.dto.response.TokenResponse;
+import com.example.wini.domain.auth.repository.RefreshTokenRepository;
+import com.example.wini.domain.member.domain.Member;
+import com.example.wini.global.security.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public TokenResponse generateToken(Member member) {
+        String newAccessToken = jwtProvider.generateAccessToken(member);
+        String newRefreshToken = jwtProvider.generateRefreshToken(member);
+
+        RefreshToken refreshToken = RefreshToken.create(member, jwtProvider.substringToken(newRefreshToken));
+        refreshTokenRepository.save(refreshToken);
+
+        return TokenResponse.of(newAccessToken, newRefreshToken);
+    }
+}

--- a/src/main/java/com/example/wini/domain/auth/service/TokenService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/TokenService.java
@@ -1,19 +1,15 @@
 package com.example.wini.domain.auth.service;
 
-import static com.example.wini.global.common.constant.SecurityConstants.REFRESH_TOKEN;
 import static com.example.wini.global.common.constant.SecurityConstants.TOKEN_BLACKLIST_CACHE_NAME;
-import static com.example.wini.global.error.exception.ErrorCode.INVALID_REFRESH_TOKEN;
-import static com.example.wini.global.error.exception.ErrorCode.MEMBER_NOT_FOUND;
 
 import com.example.wini.domain.auth.domain.RefreshToken;
 import com.example.wini.domain.auth.dto.response.TokenResponse;
 import com.example.wini.domain.auth.repository.RefreshTokenRepository;
 import com.example.wini.domain.common.util.MemberUtil;
 import com.example.wini.domain.member.domain.Member;
-import com.example.wini.domain.member.repository.MemberRepository;
-import com.example.wini.global.error.exception.CustomException;
 import com.example.wini.global.security.AuthMember;
 import com.example.wini.global.security.JwtProvider;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
@@ -24,50 +20,23 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TokenService {
 
-    private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
     private final MemberUtil memberUtil;
 
     @Transactional
-    public TokenResponse generateTokens(Member member) {
-        String accessToken = jwtProvider.generateAccessToken(member);
-        String refreshToken = jwtProvider.generateRefreshToken(member);
-
-        RefreshToken newRefreshTokenEntity = RefreshToken.create(member, jwtProvider.substringToken(refreshToken));
-        refreshTokenRepository.save(newRefreshTokenEntity);
-
-        return TokenResponse.of(accessToken, refreshToken);
-    }
-
-    @Transactional
-    public TokenResponse reissueToken(String refreshTokenHeader) {
-        String refreshToken = jwtProvider.substringToken(refreshTokenHeader);
-        validateRefreshToken(refreshToken);
-
-        return updateAndGenerateTokens(refreshToken);
-    }
-
-    private void validateRefreshToken(String refreshToken) {
-        if (!jwtProvider.validToken(refreshToken, REFRESH_TOKEN)) {
-            throw new CustomException(INVALID_REFRESH_TOKEN);
-        }
-    }
-
-    private TokenResponse updateAndGenerateTokens(String refreshToken) {
-        Long userId = jwtProvider.getMemberId(refreshToken, REFRESH_TOKEN);
-
-        Member member = memberRepository.findById(userId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
-
-        RefreshToken storedRefreshToken = refreshTokenRepository
-                .findByToken(refreshToken)
-                .orElseThrow(() -> new CustomException(INVALID_REFRESH_TOKEN));
-
+    public TokenResponse upsertTokens(Member member) {
         String newAccessToken = jwtProvider.generateAccessToken(member);
         String newRefreshToken = jwtProvider.generateRefreshToken(member);
 
-        storedRefreshToken.updateToken(newRefreshToken);
-        refreshTokenRepository.save(storedRefreshToken);
+        Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findByMemberId(member.getId());
+        if (optionalRefreshToken.isPresent()) {
+            RefreshToken storedToken = optionalRefreshToken.get();
+            storedToken.updateToken(newRefreshToken);
+        } else {
+            RefreshToken newRefreshTokenEntity = RefreshToken.create(member, newRefreshToken);
+            refreshTokenRepository.save(newRefreshTokenEntity);
+        }
 
         return TokenResponse.of(newAccessToken, newRefreshToken);
     }

--- a/src/main/java/com/example/wini/domain/auth/service/TokenService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/TokenService.java
@@ -42,18 +42,16 @@ public class TokenService {
 
     @Transactional
     public TokenResponse reissueToken(String refreshTokenHeader) {
-        String refreshToken = validateRefreshToken(refreshTokenHeader);
+        String refreshToken = jwtProvider.substringToken(refreshTokenHeader);
+        validateRefreshToken(refreshToken);
 
         return updateAndGenerateTokens(refreshToken);
     }
 
-    private String validateRefreshToken(String refreshTokenHeader) {
-        String refreshToken = jwtProvider.substringToken(refreshTokenHeader);
-
+    private void validateRefreshToken(String refreshToken) {
         if (!jwtProvider.validToken(refreshToken, REFRESH_TOKEN)) {
             throw new CustomException(INVALID_REFRESH_TOKEN);
         }
-        return refreshToken;
     }
 
     private TokenResponse updateAndGenerateTokens(String refreshToken) {

--- a/src/main/java/com/example/wini/domain/auth/service/TokenService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/TokenService.java
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class RefreshTokenService {
+public class TokenService {
 
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;

--- a/src/main/java/com/example/wini/domain/auth/service/TokenService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/TokenService.java
@@ -43,7 +43,7 @@ public class TokenService {
 
     @Transactional
     public void deleteToken(String accessToken, AuthMember authMember) {
-        Member member = memberUtil.getMember(authMember);
+        Member member = memberUtil.getCurrentMember(authMember);
         addAccessTokenToBlacklist(accessToken);
         refreshTokenRepository.deleteByMember(member);
     }

--- a/src/main/java/com/example/wini/domain/auth/service/TokenService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/TokenService.java
@@ -7,7 +7,6 @@ import com.example.wini.domain.auth.dto.response.TokenResponse;
 import com.example.wini.domain.auth.repository.RefreshTokenRepository;
 import com.example.wini.domain.common.util.MemberUtil;
 import com.example.wini.domain.member.domain.Member;
-import com.example.wini.global.security.AuthMember;
 import com.example.wini.global.security.JwtProvider;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -42,8 +41,8 @@ public class TokenService {
     }
 
     @Transactional
-    public void deleteToken(String accessToken, AuthMember authMember) {
-        Member member = memberUtil.getCurrentMember(authMember);
+    public void deleteToken(String accessToken) {
+        Member member = memberUtil.getCurrentMember();
         addAccessTokenToBlacklist(accessToken);
         refreshTokenRepository.deleteByMember(member);
     }

--- a/src/main/java/com/example/wini/domain/auth/service/TokenService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/TokenService.java
@@ -1,17 +1,22 @@
 package com.example.wini.domain.auth.service;
 
 import static com.example.wini.global.common.constant.SecurityConstants.REFRESH_TOKEN;
+import static com.example.wini.global.common.constant.SecurityConstants.TOKEN_BLACKLIST_CACHE_NAME;
 import static com.example.wini.global.error.exception.ErrorCode.INVALID_REFRESH_TOKEN;
 import static com.example.wini.global.error.exception.ErrorCode.MEMBER_NOT_FOUND;
 
 import com.example.wini.domain.auth.domain.RefreshToken;
 import com.example.wini.domain.auth.dto.response.TokenResponse;
 import com.example.wini.domain.auth.repository.RefreshTokenRepository;
+import com.example.wini.domain.common.util.MemberUtil;
 import com.example.wini.domain.member.domain.Member;
 import com.example.wini.domain.member.repository.MemberRepository;
 import com.example.wini.global.error.exception.CustomException;
+import com.example.wini.global.security.AuthMember;
 import com.example.wini.global.security.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +27,7 @@ public class TokenService {
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
+    private final MemberUtil memberUtil;
 
     @Transactional
     public TokenResponse generateTokens(Member member) {
@@ -66,5 +72,22 @@ public class TokenService {
         refreshTokenRepository.save(storedRefreshToken);
 
         return TokenResponse.of(newAccessToken, newRefreshToken);
+    }
+
+    @Transactional
+    public void deleteToken(String accessToken, AuthMember authMember) {
+        Member member = memberUtil.getMember(authMember);
+        addAccessTokenToBlacklist(accessToken);
+        refreshTokenRepository.deleteByMember(member);
+    }
+
+    @CachePut(value = TOKEN_BLACKLIST_CACHE_NAME, key = "#accessToken")
+    public boolean addAccessTokenToBlacklist(String accessToken) {
+        return true;
+    }
+
+    @Cacheable(value = TOKEN_BLACKLIST_CACHE_NAME, key = "#accessToken", unless = "#result == false")
+    public boolean isAccessTokenBlacklisted(String accessToken) {
+        return false;
     }
 }

--- a/src/main/java/com/example/wini/domain/common/annotation/Auth.java
+++ b/src/main/java/com/example/wini/domain/common/annotation/Auth.java
@@ -1,0 +1,12 @@
+package com.example.wini.domain.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal
+public @interface Auth {}

--- a/src/main/java/com/example/wini/domain/common/util/MemberUtil.java
+++ b/src/main/java/com/example/wini/domain/common/util/MemberUtil.java
@@ -1,0 +1,25 @@
+package com.example.wini.domain.common.util;
+
+import static com.example.wini.global.error.exception.ErrorCode.MEMBER_NOT_FOUND;
+
+import com.example.wini.domain.member.domain.Member;
+import com.example.wini.domain.member.repository.MemberRepository;
+import com.example.wini.global.error.exception.CustomException;
+import com.example.wini.global.security.AuthMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class MemberUtil {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public Member getMember(AuthMember authMember) {
+        return memberRepository
+                .findById(authMember.memberId())
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/wini/domain/common/util/MemberUtil.java
+++ b/src/main/java/com/example/wini/domain/common/util/MemberUtil.java
@@ -5,8 +5,9 @@ import static com.example.wini.global.error.exception.ErrorCode.MEMBER_NOT_FOUND
 import com.example.wini.domain.member.domain.Member;
 import com.example.wini.domain.member.repository.MemberRepository;
 import com.example.wini.global.error.exception.CustomException;
-import com.example.wini.global.security.AuthMember;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,9 +18,13 @@ public class MemberUtil {
     private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
-    public Member getCurrentMember(AuthMember authMember) {
-        return memberRepository
-                .findById(authMember.memberId())
-                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+    public Member getCurrentMember() {
+        Long memberId = getCurrentMemberId();
+        return memberRepository.findById(memberId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+    }
+
+    public Long getCurrentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return Long.parseLong(authentication.getName());
     }
 }

--- a/src/main/java/com/example/wini/domain/common/util/MemberUtil.java
+++ b/src/main/java/com/example/wini/domain/common/util/MemberUtil.java
@@ -17,7 +17,7 @@ public class MemberUtil {
     private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
-    public Member getMember(AuthMember authMember) {
+    public Member getCurrentMember(AuthMember authMember) {
         return memberRepository
                 .findById(authMember.memberId())
                 .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));

--- a/src/main/java/com/example/wini/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/wini/domain/member/controller/MemberController.java
@@ -1,11 +1,9 @@
 package com.example.wini.domain.member.controller;
 
-import com.example.wini.domain.common.annotation.Auth;
 import com.example.wini.domain.member.dto.request.MemberStatusUpdateRequest;
 import com.example.wini.domain.member.dto.response.MemberResponse;
 import com.example.wini.domain.member.dto.response.MemberStatusResponse;
 import com.example.wini.domain.member.service.MemberService;
-import com.example.wini.global.security.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -24,26 +22,25 @@ public class MemberController {
 
     @GetMapping("/me/status")
     @Operation(summary = "현재 내 상태", description = "현재 내 상태를 반환합니다. 현재 상태가 없을 시에는 각 필드가 Null로 반환됩니다.")
-    public MemberStatusResponse getMyStatus(@Auth AuthMember authMember) {
-        return memberService.searchMyStatus(authMember);
+    public MemberStatusResponse getMyStatus() {
+        return memberService.searchMyStatus();
     }
 
     @GetMapping("/mate/status")
     @Operation(summary = "현재 룸메 상태", description = "현재 룸메 상태를 반환합니다. 현재 상태가 없을 시에는 각 필드가 Null로 반환됩니다.")
-    public MemberStatusResponse getMateStatus(@Auth AuthMember authMember) {
-        return memberService.searchMateStatus(authMember);
+    public MemberStatusResponse getMateStatus() {
+        return memberService.searchMateStatus();
     }
 
     @PutMapping("/me/status")
     @Operation(summary = "내 상태 수정", description = "수정한 상태를 반환합니다. '계속 유지'의 경우 시간과 분은 -1로 입력해주세요.")
-    public MemberStatusResponse putStatus(
-            @Auth AuthMember authMember, @Valid @RequestBody MemberStatusUpdateRequest request) {
-        return memberService.updateStatus(authMember, request);
+    public MemberStatusResponse putStatus(@Valid @RequestBody MemberStatusUpdateRequest request) {
+        return memberService.updateStatus(request);
     }
 
     @GetMapping("/me")
     @Operation(summary = "내 정보 조회", description = "내 정보를 반환합니다.")
-    public MemberResponse getMyInfo(@Auth AuthMember authMember) {
-        return memberService.getMyInfo(authMember);
+    public MemberResponse getMyInfo() {
+        return memberService.getMyInfo();
     }
 }

--- a/src/main/java/com/example/wini/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/wini/domain/member/controller/MemberController.java
@@ -1,9 +1,11 @@
 package com.example.wini.domain.member.controller;
 
+import com.example.wini.domain.common.annotation.Auth;
 import com.example.wini.domain.member.dto.request.MemberStatusUpdateRequest;
 import com.example.wini.domain.member.dto.response.MemberResponse;
 import com.example.wini.domain.member.dto.response.MemberStatusResponse;
 import com.example.wini.domain.member.service.MemberService;
+import com.example.wini.global.security.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -22,33 +24,26 @@ public class MemberController {
 
     @GetMapping("/me/status")
     @Operation(summary = "현재 내 상태", description = "현재 내 상태를 반환합니다. 현재 상태가 없을 시에는 각 필드가 Null로 반환됩니다.")
-    public MemberStatusResponse getMyStatus(
-            // TODO: 토큰이 생기면 사용자 정보 추출하기
-            ) {
-        return memberService.searchMyStatus();
+    public MemberStatusResponse getMyStatus(@Auth AuthMember authMember) {
+        return memberService.searchMyStatus(authMember);
     }
 
     @GetMapping("/mate/status")
     @Operation(summary = "현재 룸메 상태", description = "현재 룸메 상태를 반환합니다. 현재 상태가 없을 시에는 각 필드가 Null로 반환됩니다.")
-    public MemberStatusResponse getMateStatus(
-            // TODO: 토큰이 생기면 사용자 정보 추출하기
-            ) {
-        return memberService.searchMateStatus();
+    public MemberStatusResponse getMateStatus(@Auth AuthMember authMember) {
+        return memberService.searchMateStatus(authMember);
     }
 
     @PutMapping("/me/status")
     @Operation(summary = "내 상태 수정", description = "수정한 상태를 반환합니다. '계속 유지'의 경우 시간과 분은 -1로 입력해주세요.")
     public MemberStatusResponse putStatus(
-            // TODO: 토큰이 생기면 사용자 정보 추출하기
-            @Valid @RequestBody MemberStatusUpdateRequest request) {
-        return memberService.updateStatus(request);
+            @Auth AuthMember authMember, @Valid @RequestBody MemberStatusUpdateRequest request) {
+        return memberService.updateStatus(authMember, request);
     }
 
     @GetMapping("/me")
     @Operation(summary = "내 정보 조회", description = "내 정보를 반환합니다.")
-    public MemberResponse getMyInfo(
-            // TODO: 토큰이 생기면 사용자 정보 추출하기
-            ) {
-        return memberService.getMyInfo();
+    public MemberResponse getMyInfo(@Auth AuthMember authMember) {
+        return memberService.getMyInfo(authMember);
     }
 }

--- a/src/main/java/com/example/wini/domain/member/domain/Member.java
+++ b/src/main/java/com/example/wini/domain/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.example.wini.domain.member.domain;
 
+import com.example.wini.domain.auth.dto.common.OauthMemberInfo;
 import com.example.wini.domain.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -15,6 +16,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,7 +34,7 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "status_id")
     private Status status;
 
-    @Column(nullable = false)
+    @Column
     private String email;
 
     @Column(length = 10, nullable = false)
@@ -50,6 +52,23 @@ public class Member extends BaseEntity {
     private LocalDateTime statusStartedAt;
 
     private Long statusDuration;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Member(String name, String image, String oauthId, OauthProvider oauthProvider) {
+        this.name = name;
+        this.image = image;
+        this.oauthId = oauthId;
+        this.oauthProvider = oauthProvider;
+    }
+
+    public static Member create(OauthMemberInfo oauthMemberInfo, OauthProvider oauthProvider) {
+        return Member.builder()
+                .name(oauthMemberInfo.name())
+                .image(oauthMemberInfo.imageUrl())
+                .oauthId(oauthMemberInfo.providerId())
+                .oauthProvider(oauthProvider)
+                .build();
+    }
 
     public void updateStatus(Status status, LocalDateTime statusStartedAt, Long statusDuration) {
         this.status = status;

--- a/src/main/java/com/example/wini/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/wini/domain/member/repository/MemberRepository.java
@@ -1,6 +1,10 @@
 package com.example.wini.domain.member.repository;
 
 import com.example.wini.domain.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {}
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
+
+    Optional<Member> findByOauthId(String oauthId);
+}

--- a/src/main/java/com/example/wini/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/wini/domain/member/repository/MemberRepository.java
@@ -1,10 +1,11 @@
 package com.example.wini.domain.member.repository;
 
 import com.example.wini.domain.member.domain.Member;
+import com.example.wini.domain.member.domain.OauthProvider;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
 
-    Optional<Member> findByOauthId(String oauthId);
+    Optional<Member> findByOauthIdAndOauthProvider(String oauthId, OauthProvider oauthProvider);
 }

--- a/src/main/java/com/example/wini/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/wini/domain/member/service/MemberService.java
@@ -36,7 +36,7 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public MemberStatusResponse searchMyStatus(AuthMember authMember) {
-        Member member = memberUtil.getMember(authMember);
+        Member member = memberUtil.getCurrentMember(authMember);
         if (!isStatusValid(member)) {
             return MemberStatusResponse.empty();
         }
@@ -77,7 +77,7 @@ public class MemberService {
 
     @Transactional
     public MemberStatusResponse updateStatus(AuthMember authMember, MemberStatusUpdateRequest request) {
-        Member member = memberUtil.getMember(authMember);
+        Member member = memberUtil.getCurrentMember(authMember);
 
         Status status =
                 statusRepository.findById(request.statusId()).orElseThrow(() -> new CustomException(STATUS_NOT_FOUND));
@@ -101,7 +101,7 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public MemberResponse getMyInfo(AuthMember authMember) {
-        Member member = memberUtil.getMember(authMember);
+        Member member = memberUtil.getCurrentMember(authMember);
         return MemberResponse.from(member);
     }
 }

--- a/src/main/java/com/example/wini/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/wini/domain/member/service/MemberService.java
@@ -16,7 +16,6 @@ import com.example.wini.domain.notification.domain.NotificationType;
 import com.example.wini.domain.notification.event.NotificationEvent;
 import com.example.wini.domain.room.repository.RoomRepository;
 import com.example.wini.global.error.exception.CustomException;
-import com.example.wini.global.security.AuthMember;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -35,8 +34,8 @@ public class MemberService {
     private final MemberUtil memberUtil;
 
     @Transactional(readOnly = true)
-    public MemberStatusResponse searchMyStatus(AuthMember authMember) {
-        Member member = memberUtil.getCurrentMember(authMember);
+    public MemberStatusResponse searchMyStatus() {
+        Member member = memberUtil.getCurrentMember();
         if (!isStatusValid(member)) {
             return MemberStatusResponse.empty();
         }
@@ -47,8 +46,8 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public MemberStatusResponse searchMateStatus(AuthMember authMember) {
-        Long myMemberId = authMember.memberId();
+    public MemberStatusResponse searchMateStatus() {
+        Long myMemberId = memberUtil.getCurrentMemberId();
         Member mate = memberRepository
                 .findRoommateWithStatusByMemberId(myMemberId)
                 .orElseThrow(() -> new CustomException(MATE_NOT_FOUND));
@@ -76,8 +75,8 @@ public class MemberService {
     }
 
     @Transactional
-    public MemberStatusResponse updateStatus(AuthMember authMember, MemberStatusUpdateRequest request) {
-        Member member = memberUtil.getCurrentMember(authMember);
+    public MemberStatusResponse updateStatus(MemberStatusUpdateRequest request) {
+        Member member = memberUtil.getCurrentMember();
 
         Status status =
                 statusRepository.findById(request.statusId()).orElseThrow(() -> new CustomException(STATUS_NOT_FOUND));
@@ -100,8 +99,8 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public MemberResponse getMyInfo(AuthMember authMember) {
-        Member member = memberUtil.getCurrentMember(authMember);
+    public MemberResponse getMyInfo() {
+        Member member = memberUtil.getCurrentMember();
         return MemberResponse.from(member);
     }
 }

--- a/src/main/java/com/example/wini/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/wini/domain/member/service/MemberService.java
@@ -1,9 +1,9 @@
 package com.example.wini.domain.member.service;
 
 import static com.example.wini.global.error.exception.ErrorCode.MATE_NOT_FOUND;
-import static com.example.wini.global.error.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static com.example.wini.global.error.exception.ErrorCode.STATUS_NOT_FOUND;
 
+import com.example.wini.domain.common.util.MemberUtil;
 import com.example.wini.domain.member.domain.Member;
 import com.example.wini.domain.member.domain.Status;
 import com.example.wini.domain.member.dto.common.ReservedTimeInfo;
@@ -16,6 +16,7 @@ import com.example.wini.domain.notification.domain.NotificationType;
 import com.example.wini.domain.notification.event.NotificationEvent;
 import com.example.wini.domain.room.repository.RoomRepository;
 import com.example.wini.global.error.exception.CustomException;
+import com.example.wini.global.security.AuthMember;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -31,15 +32,11 @@ public class MemberService {
     private final RoomRepository roomRepository;
     private final StatusRepository statusRepository;
     private final ApplicationEventPublisher eventPublisher;
-
-    private static final Long MEMBER_ID = 1L;
+    private final MemberUtil memberUtil;
 
     @Transactional(readOnly = true)
-    public MemberStatusResponse searchMyStatus() {
-        Member member = memberRepository
-                .findWithStatusByMemberId(MEMBER_ID)
-                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
-
+    public MemberStatusResponse searchMyStatus(AuthMember authMember) {
+        Member member = memberUtil.getMember(authMember);
         if (!isStatusValid(member)) {
             return MemberStatusResponse.empty();
         }
@@ -50,9 +47,10 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public MemberStatusResponse searchMateStatus() {
+    public MemberStatusResponse searchMateStatus(AuthMember authMember) {
+        Long myMemberId = authMember.memberId();
         Member mate = memberRepository
-                .findRoommateWithStatusByMemberId(MEMBER_ID)
+                .findRoommateWithStatusByMemberId(myMemberId)
                 .orElseThrow(() -> new CustomException(MATE_NOT_FOUND));
 
         if (!isStatusValid(mate)) {
@@ -78,8 +76,8 @@ public class MemberService {
     }
 
     @Transactional
-    public MemberStatusResponse updateStatus(MemberStatusUpdateRequest request) {
-        Member member = memberRepository.findById(MEMBER_ID).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+    public MemberStatusResponse updateStatus(AuthMember authMember, MemberStatusUpdateRequest request) {
+        Member member = memberUtil.getMember(authMember);
 
         Status status =
                 statusRepository.findById(request.statusId()).orElseThrow(() -> new CustomException(STATUS_NOT_FOUND));
@@ -88,7 +86,7 @@ public class MemberService {
         Long statusDurationSeconds = statusDuration.getSeconds();
 
         member.updateStatus(status, request.startedAt(), statusDurationSeconds);
-        notifyRoommateOfStatusUpdate(MEMBER_ID);
+        notifyRoommateOfStatusUpdate(member.getId());
 
         return MemberStatusResponse.from(member, request.reservedTimeInfo());
     }
@@ -102,8 +100,8 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public MemberResponse getMyInfo() {
-        Member member = memberRepository.findById(MEMBER_ID).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+    public MemberResponse getMyInfo(AuthMember authMember) {
+        Member member = memberUtil.getMember(authMember);
         return MemberResponse.from(member);
     }
 }

--- a/src/main/java/com/example/wini/domain/notification/controller/FirebaseTokenController.java
+++ b/src/main/java/com/example/wini/domain/notification/controller/FirebaseTokenController.java
@@ -1,7 +1,9 @@
 package com.example.wini.domain.notification.controller;
 
+import com.example.wini.domain.common.annotation.Auth;
 import com.example.wini.domain.notification.dto.request.FirebaseTokenSaveRequest;
 import com.example.wini.domain.notification.service.FirebaseTokenService;
+import com.example.wini.global.security.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -19,16 +21,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class FirebaseTokenController {
 
-    private static final long MEMBER_ID = 1L;
-
     private final FirebaseTokenService firebaseTokenService;
 
     @PostMapping("/tokens")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "알림 토큰 저장", description = "FCM 토큰을 저장합니다.")
-    public void saveFirebaseToken(
-            // TODO: 사용자 정보
-            @Valid @RequestBody FirebaseTokenSaveRequest request) {
-        firebaseTokenService.saveFirebaseToken(MEMBER_ID, request);
+    public void saveFirebaseToken(@Auth AuthMember authMember, @Valid @RequestBody FirebaseTokenSaveRequest request) {
+        firebaseTokenService.saveFirebaseToken(authMember, request);
     }
 }

--- a/src/main/java/com/example/wini/domain/notification/controller/FirebaseTokenController.java
+++ b/src/main/java/com/example/wini/domain/notification/controller/FirebaseTokenController.java
@@ -1,9 +1,7 @@
 package com.example.wini.domain.notification.controller;
 
-import com.example.wini.domain.common.annotation.Auth;
 import com.example.wini.domain.notification.dto.request.FirebaseTokenSaveRequest;
 import com.example.wini.domain.notification.service.FirebaseTokenService;
-import com.example.wini.global.security.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -26,7 +24,7 @@ public class FirebaseTokenController {
     @PostMapping("/tokens")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "알림 토큰 저장", description = "FCM 토큰을 저장합니다.")
-    public void saveFirebaseToken(@Auth AuthMember authMember, @Valid @RequestBody FirebaseTokenSaveRequest request) {
-        firebaseTokenService.saveFirebaseToken(authMember, request);
+    public void saveFirebaseToken(@Valid @RequestBody FirebaseTokenSaveRequest request) {
+        firebaseTokenService.saveFirebaseToken(request);
     }
 }

--- a/src/main/java/com/example/wini/domain/notification/domain/NotificationType.java
+++ b/src/main/java/com/example/wini/domain/notification/domain/NotificationType.java
@@ -9,7 +9,7 @@ public enum NotificationType {
     // TODO: 문구 확정되면 변경하기
     NEW_ROOMMATE("join", "Wini", "룸메이트가 나의 초대에 응했어요.\n이제 함께 Wini를 시작해보세요."),
     NEW_NOTE("note", "Wini", "24시간 내 사라지는 룸메이트의 마음쪽지가 도착했어요."),
-    NEW_STATUS("status", "Wini", "룸메이트의 현재 상태를 변경했어요."),
+    NEW_STATUS("status", "Wini", "룸메이트가 현재 상태를 변경했어요."),
     ;
 
     private final String type;

--- a/src/main/java/com/example/wini/domain/notification/service/FirebaseTokenService.java
+++ b/src/main/java/com/example/wini/domain/notification/service/FirebaseTokenService.java
@@ -5,7 +5,6 @@ import com.example.wini.domain.member.domain.Member;
 import com.example.wini.domain.notification.domain.FirebaseToken;
 import com.example.wini.domain.notification.dto.request.FirebaseTokenSaveRequest;
 import com.example.wini.domain.notification.repository.FirebaseTokenRepository;
-import com.example.wini.global.security.AuthMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,8 +17,8 @@ public class FirebaseTokenService {
     private final MemberUtil memberUtil;
 
     @Transactional
-    public void saveFirebaseToken(AuthMember authMember, FirebaseTokenSaveRequest request) {
-        Member member = memberUtil.getCurrentMember(authMember);
+    public void saveFirebaseToken(FirebaseTokenSaveRequest request) {
+        Member member = memberUtil.getCurrentMember();
         String token = request.token();
 
         firebaseTokenRepository.deleteByToken(token);

--- a/src/main/java/com/example/wini/domain/notification/service/FirebaseTokenService.java
+++ b/src/main/java/com/example/wini/domain/notification/service/FirebaseTokenService.java
@@ -19,7 +19,7 @@ public class FirebaseTokenService {
 
     @Transactional
     public void saveFirebaseToken(AuthMember authMember, FirebaseTokenSaveRequest request) {
-        Member member = memberUtil.getMember(authMember);
+        Member member = memberUtil.getCurrentMember(authMember);
         String token = request.token();
 
         firebaseTokenRepository.deleteByToken(token);

--- a/src/main/java/com/example/wini/domain/notification/service/FirebaseTokenService.java
+++ b/src/main/java/com/example/wini/domain/notification/service/FirebaseTokenService.java
@@ -1,13 +1,11 @@
 package com.example.wini.domain.notification.service;
 
-import static com.example.wini.global.error.exception.ErrorCode.MEMBER_NOT_FOUND;
-
+import com.example.wini.domain.common.util.MemberUtil;
 import com.example.wini.domain.member.domain.Member;
-import com.example.wini.domain.member.repository.MemberRepository;
 import com.example.wini.domain.notification.domain.FirebaseToken;
 import com.example.wini.domain.notification.dto.request.FirebaseTokenSaveRequest;
 import com.example.wini.domain.notification.repository.FirebaseTokenRepository;
-import com.example.wini.global.error.exception.CustomException;
+import com.example.wini.global.security.AuthMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,11 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class FirebaseTokenService {
 
     private final FirebaseTokenRepository firebaseTokenRepository;
-    private final MemberRepository memberRepository;
+    private final MemberUtil memberUtil;
 
     @Transactional
-    public void saveFirebaseToken(Long memberId, FirebaseTokenSaveRequest request) {
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+    public void saveFirebaseToken(AuthMember authMember, FirebaseTokenSaveRequest request) {
+        Member member = memberUtil.getMember(authMember);
         String token = request.token();
 
         firebaseTokenRepository.deleteByToken(token);

--- a/src/main/java/com/example/wini/domain/room/controller/RoomController.java
+++ b/src/main/java/com/example/wini/domain/room/controller/RoomController.java
@@ -1,10 +1,8 @@
 package com.example.wini.domain.room.controller;
 
-import com.example.wini.domain.common.annotation.Auth;
 import com.example.wini.domain.room.dto.request.RoomJoinRequest;
 import com.example.wini.domain.room.dto.response.RoomResponse;
 import com.example.wini.domain.room.service.RoomService;
-import com.example.wini.global.security.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -27,14 +25,14 @@ public class RoomController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "초대코드 생성", description = "생성된 초대코드를 반환합니다.")
-    public RoomResponse createRoom(@Auth AuthMember authMember) {
-        return roomService.createRoom(authMember);
+    public RoomResponse createRoom() {
+        return roomService.createRoom();
     }
 
     @PostMapping("/join")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "초대코드 입력", description = "초대코드와 연결된 방 정보를 반환합니다.")
-    public RoomResponse joinRoom(@Auth AuthMember authMember, @Valid @RequestBody RoomJoinRequest request) {
-        return roomService.joinRoom(authMember, request);
+    public RoomResponse joinRoom(@Valid @RequestBody RoomJoinRequest request) {
+        return roomService.joinRoom(request);
     }
 }

--- a/src/main/java/com/example/wini/domain/room/controller/RoomController.java
+++ b/src/main/java/com/example/wini/domain/room/controller/RoomController.java
@@ -1,8 +1,10 @@
 package com.example.wini.domain.room.controller;
 
+import com.example.wini.domain.common.annotation.Auth;
 import com.example.wini.domain.room.dto.request.RoomJoinRequest;
 import com.example.wini.domain.room.dto.response.RoomResponse;
 import com.example.wini.domain.room.service.RoomService;
+import com.example.wini.global.security.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -20,26 +22,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class RoomController {
 
-    private static final Long MEMBER_ID = 1L;
-    private static final Long MATE_ID = 2L;
-
     private final RoomService roomService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "초대코드 생성", description = "생성된 초대코드를 반환합니다.")
-    public RoomResponse createRoom(
-            // TODO: 토큰이 생기면 사용자 정보 추출하기
-            ) {
-        return roomService.createRoom(MEMBER_ID);
+    public RoomResponse createRoom(@Auth AuthMember authMember) {
+        return roomService.createRoom(authMember);
     }
 
     @PostMapping("/join")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "초대코드 입력", description = "초대코드와 연결된 방 정보를 반환합니다.")
-    public RoomResponse joinRoom(
-            // TODO: 토큰이 생기면 사용자 정보 추출하기
-            @Valid @RequestBody RoomJoinRequest request) {
-        return roomService.joinRoom(MATE_ID, request);
+    public RoomResponse joinRoom(@Auth AuthMember authMember, @Valid @RequestBody RoomJoinRequest request) {
+        return roomService.joinRoom(authMember, request);
     }
 }

--- a/src/main/java/com/example/wini/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/wini/domain/room/service/RoomService.java
@@ -20,7 +20,6 @@ import com.example.wini.domain.room.entity.Room;
 import com.example.wini.domain.room.repository.MemberRoomRepository;
 import com.example.wini.domain.room.repository.RoomRepository;
 import com.example.wini.global.error.exception.CustomException;
-import com.example.wini.global.security.AuthMember;
 import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -38,8 +37,8 @@ public class RoomService {
     private final MemberUtil memberUtil;
 
     @Transactional
-    public RoomResponse createRoom(AuthMember authMember) {
-        Member member = memberUtil.getCurrentMember(authMember);
+    public RoomResponse createRoom() {
+        Member member = memberUtil.getCurrentMember();
         validateMemberCanJoinRoom(member.getId());
 
         String roomCode = generateUniqueRoomCode();
@@ -74,8 +73,8 @@ public class RoomService {
     }
 
     @Transactional
-    public RoomResponse joinRoom(AuthMember authMember, RoomJoinRequest request) {
-        Member member = memberUtil.getCurrentMember(authMember);
+    public RoomResponse joinRoom(RoomJoinRequest request) {
+        Member member = memberUtil.getCurrentMember();
         validateMemberCanJoinRoom(member.getId());
 
         Room room = roomRepository

--- a/src/main/java/com/example/wini/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/wini/domain/room/service/RoomService.java
@@ -5,10 +5,10 @@ import static com.example.wini.global.common.constant.RoomConstants.ROOM_CODE_LE
 import static com.example.wini.global.common.constant.RoomConstants.ROOM_MEMBER_MAX_COUNT;
 import static com.example.wini.global.error.exception.ErrorCode.ALREADY_JOIN_ROOM;
 import static com.example.wini.global.error.exception.ErrorCode.MATE_NOT_FOUND;
-import static com.example.wini.global.error.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static com.example.wini.global.error.exception.ErrorCode.ROOM_IS_FULL;
 import static com.example.wini.global.error.exception.ErrorCode.ROOM_NOT_FOUND;
 
+import com.example.wini.domain.common.util.MemberUtil;
 import com.example.wini.domain.member.domain.Member;
 import com.example.wini.domain.member.repository.MemberRepository;
 import com.example.wini.domain.notification.domain.NotificationType;
@@ -20,6 +20,7 @@ import com.example.wini.domain.room.entity.Room;
 import com.example.wini.domain.room.repository.MemberRoomRepository;
 import com.example.wini.domain.room.repository.RoomRepository;
 import com.example.wini.global.error.exception.CustomException;
+import com.example.wini.global.security.AuthMember;
 import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -34,11 +35,12 @@ public class RoomService {
     private final RoomRepository roomRepository;
     private final MemberRoomRepository memberRoomRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final MemberUtil memberUtil;
 
     @Transactional
-    public RoomResponse createRoom(Long memberId) {
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
-        validateMemberCanJoinRoom(memberId);
+    public RoomResponse createRoom(AuthMember authMember) {
+        Member member = memberUtil.getMember(authMember);
+        validateMemberCanJoinRoom(member.getId());
 
         String roomCode = generateUniqueRoomCode();
 
@@ -72,10 +74,9 @@ public class RoomService {
     }
 
     @Transactional
-    public RoomResponse joinRoom(Long memberId, RoomJoinRequest request) {
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
-
-        validateMemberCanJoinRoom(memberId);
+    public RoomResponse joinRoom(AuthMember authMember, RoomJoinRequest request) {
+        Member member = memberUtil.getMember(authMember);
+        validateMemberCanJoinRoom(member.getId());
 
         Room room = roomRepository
                 .findOpenRoomByRoomCode(request.roomCode())
@@ -85,7 +86,7 @@ public class RoomService {
 
         MemberRoom memberRoom = MemberRoom.create(member, room);
         memberRoomRepository.save(memberRoom);
-        notifyRoommateOfNewJoiner(memberId);
+        notifyRoommateOfNewJoiner(member.getId());
 
         return RoomResponse.from(room);
     }

--- a/src/main/java/com/example/wini/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/wini/domain/room/service/RoomService.java
@@ -39,7 +39,7 @@ public class RoomService {
 
     @Transactional
     public RoomResponse createRoom(AuthMember authMember) {
-        Member member = memberUtil.getMember(authMember);
+        Member member = memberUtil.getCurrentMember(authMember);
         validateMemberCanJoinRoom(member.getId());
 
         String roomCode = generateUniqueRoomCode();
@@ -75,7 +75,7 @@ public class RoomService {
 
     @Transactional
     public RoomResponse joinRoom(AuthMember authMember, RoomJoinRequest request) {
-        Member member = memberUtil.getMember(authMember);
+        Member member = memberUtil.getCurrentMember(authMember);
         validateMemberCanJoinRoom(member.getId());
 
         Room room = roomRepository

--- a/src/main/java/com/example/wini/global/common/constant/OauthConstants.java
+++ b/src/main/java/com/example/wini/global/common/constant/OauthConstants.java
@@ -1,0 +1,8 @@
+package com.example.wini.global.common.constant;
+
+public class OauthConstants {
+
+    public static final String KAKAO_BASE_URL = "https://kauth.kakao.com";
+
+    private OauthConstants() {}
+}

--- a/src/main/java/com/example/wini/global/common/constant/SecurityConstants.java
+++ b/src/main/java/com/example/wini/global/common/constant/SecurityConstants.java
@@ -15,5 +15,7 @@ public class SecurityConstants {
 
     public static final String JWT_TYPE = "JWT";
 
+    public static final String TOKEN_BLACKLIST_CACHE_NAME = "blacklistedTokens";
+
     private SecurityConstants() {}
 }

--- a/src/main/java/com/example/wini/global/common/constant/SecurityConstants.java
+++ b/src/main/java/com/example/wini/global/common/constant/SecurityConstants.java
@@ -1,0 +1,19 @@
+package com.example.wini.global.common.constant;
+
+public class SecurityConstants {
+
+    public static final String ACCESS_TOKEN = "accessToken";
+    public static final String REFRESH_TOKEN = "refreshToken";
+
+    public static final String HEADER_AUTHORIZATION = "Authorization";
+    public static final String BEARER_TOKEN_PREFIX = "Bearer ";
+
+    public static final String[] PUBLIC_URLS = {
+        "/", "/auth/kakao/**", "/auth/login/**", "/v3/api-docs", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html"
+    };
+    public static final String REISSUE_URL = "/auth/reissue";
+
+    public static final String JWT_TYPE = "JWT";
+
+    private SecurityConstants() {}
+}

--- a/src/main/java/com/example/wini/global/common/constant/SecurityConstants.java
+++ b/src/main/java/com/example/wini/global/common/constant/SecurityConstants.java
@@ -9,7 +9,14 @@ public class SecurityConstants {
     public static final String BEARER_TOKEN_PREFIX = "Bearer ";
 
     public static final String[] PUBLIC_URLS = {
-        "/", "/auth/kakao/**", "/auth/login/**", "/v3/api-docs", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html"
+        "/",
+        "/auth/kakao/**",
+        "/auth/login/**",
+        "/api-docs",
+        "/v3/api-docs",
+        "/v3/api-docs/**",
+        "/swagger-ui/**",
+        "/swagger-ui.html"
     };
     public static final String REISSUE_URL = "/auth/reissue";
 

--- a/src/main/java/com/example/wini/global/config/CacheConfig.java
+++ b/src/main/java/com/example/wini/global/config/CacheConfig.java
@@ -1,0 +1,21 @@
+package com.example.wini.global.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.concurrent.TimeUnit;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CaffeineCacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        cacheManager.setCaffeine(
+                Caffeine.newBuilder().expireAfterWrite(30, TimeUnit.MINUTES).maximumSize(10000));
+        return cacheManager;
+    }
+}

--- a/src/main/java/com/example/wini/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/example/wini/global/config/JpaAuditingConfig.java
@@ -1,10 +1,13 @@
 package com.example.wini.global.config;
 
+import com.example.wini.global.security.AuthMember;
 import java.util.Optional;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 @EnableJpaAuditing
 @Configuration
@@ -12,7 +15,21 @@ public class JpaAuditingConfig {
 
     @Bean
     public AuditorAware<Long> auditorAware() {
-        // TODO: 인증인가 구현하면 여기도 바꾸기
-        return () -> Optional.of(1L);
+        return () -> {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication == null
+                    || !authentication.isAuthenticated()
+                    || authentication
+                            instanceof org.springframework.security.authentication.AnonymousAuthenticationToken) {
+                return Optional.empty();
+            }
+
+            Object principal = authentication.getPrincipal();
+            if (principal instanceof AuthMember authMember) {
+                return Optional.of(authMember.memberId());
+            }
+
+            return Optional.empty();
+        };
     }
 }

--- a/src/main/java/com/example/wini/global/config/RestClientConfig.java
+++ b/src/main/java/com/example/wini/global/config/RestClientConfig.java
@@ -1,0 +1,51 @@
+package com.example.wini.global.config;
+
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.core5.util.Timeout;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+import org.springframework.web.util.DefaultUriBuilderFactory.EncodingMode;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient restClient(RestClient.Builder builder) {
+
+        DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory();
+        factory.setEncodingMode(EncodingMode.NONE);
+
+        return builder.uriBuilderFactory(factory)
+                .requestFactory(customHttpRequestFactory())
+                .build();
+    }
+
+    @Bean
+    public HttpComponentsClientHttpRequestFactory customHttpRequestFactory() {
+
+        // 풀링 설정 (대량 요청 대비)
+        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+        connectionManager.setMaxTotal(100); // 최대 연결 수
+        connectionManager.setDefaultMaxPerRoute(20); // 호스트 당 연결 수
+
+        // 타임아웃 설정
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(Timeout.ofSeconds(5)) // 연결
+                .setResponseTimeout(Timeout.ofSeconds(10)) // 데이터 읽기
+                .build();
+
+        // HttpClient 생성 및 설정
+        HttpClient httpClient = HttpClientBuilder.create()
+                .setConnectionManager(connectionManager) // 커넥션 매니저 적용
+                .setDefaultRequestConfig(requestConfig) // 요청 설정 적용
+                .build();
+
+        return new HttpComponentsClientHttpRequestFactory(httpClient);
+    }
+}

--- a/src/main/java/com/example/wini/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/wini/global/config/SecurityConfig.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -23,7 +22,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-@Profile("!test")
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor

--- a/src/main/java/com/example/wini/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/wini/global/config/SecurityConfig.java
@@ -1,0 +1,82 @@
+package com.example.wini.global.config;
+
+import static com.example.wini.global.common.constant.SecurityConstants.PUBLIC_URLS;
+import static com.example.wini.global.common.constant.SecurityConstants.REISSUE_URL;
+
+import com.example.wini.global.security.JwtAuthenticationEntryPoint;
+import com.example.wini.global.security.JwtAuthenticationFilter;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    // TODO: 이것도 상수로 관리할지 고민..
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigin;
+
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    @Order(0)
+    SecurityFilterChain publicChain(HttpSecurity http) throws Exception {
+        return http.securityMatcher(PUBLIC_URLS)
+                .cors(c -> c.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(a -> a.anyRequest().permitAll())
+                .build();
+    }
+
+    @Bean
+    @Order(1)
+    SecurityFilterChain protectedChain(HttpSecurity http) throws Exception {
+        return http.securityMatcher("/**")
+                .cors(c -> c.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(a ->
+                        a.requestMatchers(REISSUE_URL).permitAll().anyRequest().authenticated())
+                .exceptionHandling(e -> e.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        List<String> allowedOrigins = Arrays.asList(allowedOrigin.split(","));
+
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.setAllowedOriginPatterns(allowedOrigins);
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/src/main/java/com/example/wini/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/wini/global/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -22,6 +23,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+@Profile("!test")
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor

--- a/src/main/java/com/example/wini/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/wini/global/config/SwaggerConfig.java
@@ -1,20 +1,45 @@
 package com.example.wini.global.config;
 
+import static com.example.wini.global.common.constant.SecurityConstants.HEADER_AUTHORIZATION;
+
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 
 @Configuration
 public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
-        return new OpenAPI().addServersItem(new Server().url("/")).info(apiInfo());
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(apiInfo())
+                .components(securitySchemeComponents())
+                .addSecurityItem(securityRequirement());
     }
 
     private Info apiInfo() {
         return new Info().title("Wini API 문서").version("v1.0.0");
+    }
+
+    private Components securitySchemeComponents() {
+        SecurityScheme bearerAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("Bearer")
+                .bearerFormat(HEADER_AUTHORIZATION)
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+
+        return new Components().addSecuritySchemes(HEADER_AUTHORIZATION, bearerAuth);
+    }
+
+    private SecurityRequirement securityRequirement() {
+        return new SecurityRequirement().addList(HEADER_AUTHORIZATION);
     }
 }

--- a/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
@@ -21,6 +21,15 @@ public enum ErrorCode {
     // Authentication
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "권한이 거부되었습니다."),
+    TOKEN_REQUIRED(HttpStatus.BAD_REQUEST, "토큰이 필요합니다."),
+    INVALID_TOKEN_SIGNATURE(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 서명입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST, "지원하지 않는 토큰 형식입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh 토큰입니다."),
+    MALFORMED_TOKEN(HttpStatus.BAD_REQUEST, "올바르지 않은 형식의 토큰입니다."),
+    TOKEN_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "토큰 검증에 실패했습니다."),
+    BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "로그아웃 처리된 토큰입니다."),
+    KAKAO_TOKEN_ISSUANCE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 액세스 토큰 발급에 실패했습니다."),
 
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),

--- a/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     TOKEN_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "토큰 검증에 실패했습니다."),
     BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "로그아웃 처리된 토큰입니다."),
     KAKAO_TOKEN_ISSUANCE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 액세스 토큰 발급에 실패했습니다."),
+    KAKAO_USERINFO_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 사용자 정보 조회에 실패했습니다."),
 
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),

--- a/src/main/java/com/example/wini/global/security/AuthMember.java
+++ b/src/main/java/com/example/wini/global/security/AuthMember.java
@@ -1,0 +1,28 @@
+package com.example.wini.global.security;
+
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public record AuthMember(Long memberId) implements UserDetails {
+
+    public static AuthMember of(Long memberId) {
+        return new AuthMember(memberId);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.memberId.toString();
+    }
+}

--- a/src/main/java/com/example/wini/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/wini/global/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package com.example.wini.global.security;
+
+import static com.example.wini.global.error.exception.ErrorCode.UNAUTHORIZED;
+
+import com.example.wini.global.error.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponse errorResponse = ErrorResponse.of(authException.getClass().getName(), UNAUTHORIZED.getMessage());
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+        response.getWriter().flush();
+    }
+}

--- a/src/main/java/com/example/wini/global/security/JwtAuthenticationException.java
+++ b/src/main/java/com/example/wini/global/security/JwtAuthenticationException.java
@@ -1,0 +1,19 @@
+package com.example.wini.global.security;
+
+import com.example.wini.global.error.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+
+public class JwtAuthenticationException extends AuthenticationException {
+
+    private final ErrorCode errorCode;
+
+    public JwtAuthenticationException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return errorCode.getHttpStatus();
+    }
+}

--- a/src/main/java/com/example/wini/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/wini/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,75 @@
+package com.example.wini.global.security;
+
+import static com.example.wini.global.common.constant.SecurityConstants.ACCESS_TOKEN;
+import static com.example.wini.global.common.constant.SecurityConstants.BEARER_TOKEN_PREFIX;
+import static com.example.wini.global.common.constant.SecurityConstants.HEADER_AUTHORIZATION;
+import static com.example.wini.global.common.constant.SecurityConstants.REFRESH_TOKEN;
+import static com.example.wini.global.common.constant.SecurityConstants.REISSUE_URL;
+
+import com.example.wini.global.error.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        final String uri = request.getServletPath();
+        final boolean isReissue = uri.equals(REISSUE_URL);
+
+        String authorization = request.getHeader(HEADER_AUTHORIZATION);
+        if (authorization == null || !authorization.startsWith(BEARER_TOKEN_PREFIX)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            String token = jwtProvider.substringToken(authorization);
+            if (isReissue) {
+                jwtProvider.validToken(token, REFRESH_TOKEN);
+            } else {
+                if (jwtProvider.validToken(token, ACCESS_TOKEN)) {
+                    AuthMember authMember = jwtProvider.getAuthentication(token, ACCESS_TOKEN);
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(authMember, null, authMember.getAuthorities());
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            }
+        } catch (JwtAuthenticationException e) {
+            setErrorResponse(response, e);
+            return;
+        } catch (Exception e) {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private void setErrorResponse(HttpServletResponse response, JwtAuthenticationException e) throws IOException {
+        response.setStatus(e.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponse errorResponse = ErrorResponse.of(e.getClass().getName(), e.getMessage());
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+        response.getWriter().flush();
+    }
+}

--- a/src/main/java/com/example/wini/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/wini/global/security/JwtAuthenticationFilter.java
@@ -5,7 +5,9 @@ import static com.example.wini.global.common.constant.SecurityConstants.BEARER_T
 import static com.example.wini.global.common.constant.SecurityConstants.HEADER_AUTHORIZATION;
 import static com.example.wini.global.common.constant.SecurityConstants.REFRESH_TOKEN;
 import static com.example.wini.global.common.constant.SecurityConstants.REISSUE_URL;
+import static com.example.wini.global.error.exception.ErrorCode.BLACKLISTED_TOKEN;
 
+import com.example.wini.domain.auth.service.TokenService;
 import com.example.wini.global.error.ErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
@@ -26,6 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
+    private final TokenService tokenService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -45,6 +48,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (isReissue) {
                 jwtProvider.validToken(token, REFRESH_TOKEN);
             } else {
+                boolean isBlacklisted = tokenService.isAccessTokenBlacklisted(token);
+                if (isBlacklisted) {
+                    throw new JwtAuthenticationException(BLACKLISTED_TOKEN);
+                }
+
                 if (jwtProvider.validToken(token, ACCESS_TOKEN)) {
                     AuthMember authMember = jwtProvider.getAuthentication(token, ACCESS_TOKEN);
                     UsernamePasswordAuthenticationToken authentication =

--- a/src/main/java/com/example/wini/global/security/JwtProvider.java
+++ b/src/main/java/com/example/wini/global/security/JwtProvider.java
@@ -125,4 +125,9 @@ public class JwtProvider {
                 .parseSignedClaims(token)
                 .getPayload();
     }
+
+    public Long getMemberId(String token, String tokenType) {
+        Claims claims = getMemberInfoFromToken(token, tokenType);
+        return Long.parseLong(claims.getSubject());
+    }
 }

--- a/src/main/java/com/example/wini/global/security/JwtProvider.java
+++ b/src/main/java/com/example/wini/global/security/JwtProvider.java
@@ -24,11 +24,9 @@ import java.util.Date;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
-@Profile("!test")
 @Service
 @RequiredArgsConstructor
 public class JwtProvider {

--- a/src/main/java/com/example/wini/global/security/JwtProvider.java
+++ b/src/main/java/com/example/wini/global/security/JwtProvider.java
@@ -1,0 +1,128 @@
+package com.example.wini.global.security;
+
+import static com.example.wini.global.common.constant.SecurityConstants.ACCESS_TOKEN;
+import static com.example.wini.global.common.constant.SecurityConstants.BEARER_TOKEN_PREFIX;
+import static com.example.wini.global.common.constant.SecurityConstants.JWT_TYPE;
+import static com.example.wini.global.error.exception.ErrorCode.EXPIRED_TOKEN;
+import static com.example.wini.global.error.exception.ErrorCode.INTERNAL_SERVER_ERROR;
+import static com.example.wini.global.error.exception.ErrorCode.INVALID_TOKEN_SIGNATURE;
+import static com.example.wini.global.error.exception.ErrorCode.MALFORMED_TOKEN;
+import static com.example.wini.global.error.exception.ErrorCode.TOKEN_REQUIRED;
+import static com.example.wini.global.error.exception.ErrorCode.UNSUPPORTED_TOKEN;
+
+import com.example.wini.domain.member.domain.Member;
+import com.example.wini.global.error.exception.CustomException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.DecodingException;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    @Value("${jwt.issuer}")
+    private String issuer;
+
+    @Value("${jwt.accessToken.secret-key}")
+    private String accessTokenSecret;
+
+    @Value("${jwt.accessToken.expiration-time}")
+    private Long accessTokenExpiration;
+
+    @Value("${jwt.refreshToken.secret-key}")
+    private String refreshTokenSecret;
+
+    @Value("${jwt.refreshToken.expiration-time}")
+    private Long refreshTokenExpiration;
+
+    private SecretKey accessTokenKey;
+    private SecretKey refreshTokenKey;
+
+    @PostConstruct
+    public void init() {
+        this.accessTokenKey = Keys.hmacShaKeyFor(accessTokenSecret.getBytes());
+        this.refreshTokenKey = Keys.hmacShaKeyFor(refreshTokenSecret.getBytes());
+    }
+
+    public String generateAccessToken(Member member) {
+        Date now = new Date();
+        return BEARER_TOKEN_PREFIX
+                + Jwts.builder()
+                        .header()
+                        .type(JWT_TYPE)
+                        .and()
+                        .issuer(issuer)
+                        .subject(String.valueOf(member.getId()))
+                        .issuedAt(now)
+                        .expiration(new Date(now.getTime() + accessTokenExpiration * 1000))
+                        .signWith(accessTokenKey)
+                        .compact();
+    }
+
+    public String generateRefreshToken(Member member) {
+        Date now = new Date();
+        return BEARER_TOKEN_PREFIX
+                + Jwts.builder()
+                        .header()
+                        .type(JWT_TYPE)
+                        .and()
+                        .issuer(issuer)
+                        .subject(String.valueOf(member.getId()))
+                        .issuedAt(now)
+                        .expiration(new Date(now.getTime() + refreshTokenExpiration * 1000))
+                        .signWith(refreshTokenKey)
+                        .compact();
+    }
+
+    public String substringToken(String tokenValue) {
+        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_TOKEN_PREFIX)) {
+            return tokenValue.substring(BEARER_TOKEN_PREFIX.length());
+        }
+        throw new CustomException(TOKEN_REQUIRED);
+    }
+
+    public boolean validToken(String token, String tokenType) {
+        try {
+            getMemberInfoFromToken(token, tokenType);
+            return true;
+        } catch (SecurityException e) {
+            throw new JwtAuthenticationException(INVALID_TOKEN_SIGNATURE);
+        } catch (ExpiredJwtException e) {
+            throw new JwtAuthenticationException(EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            throw new JwtAuthenticationException(UNSUPPORTED_TOKEN);
+        } catch (DecodingException | MalformedJwtException e) {
+            throw new JwtAuthenticationException(MALFORMED_TOKEN);
+        } catch (Exception e) {
+            throw new JwtAuthenticationException(INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public AuthMember getAuthentication(String token, String tokenType) {
+        Claims claims = getMemberInfoFromToken(token, tokenType);
+        Long memberId = Long.parseLong(claims.getSubject());
+        return AuthMember.of(memberId);
+    }
+
+    private Claims getMemberInfoFromToken(String token, String tokenType) {
+        SecretKey key = ACCESS_TOKEN.equals(tokenType) ? accessTokenKey : refreshTokenKey;
+
+        return Jwts.parser()
+                .verifyWith(key)
+                .requireIssuer(issuer)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/com/example/wini/global/security/JwtProvider.java
+++ b/src/main/java/com/example/wini/global/security/JwtProvider.java
@@ -24,9 +24,11 @@ import java.util.Date;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+@Profile("!test")
 @Service
 @RequiredArgsConstructor
 public class JwtProvider {

--- a/src/main/java/com/example/wini/infra/kakao/client/KakaoClient.java
+++ b/src/main/java/com/example/wini/infra/kakao/client/KakaoClient.java
@@ -9,7 +9,6 @@ import com.example.wini.infra.kakao.dto.KakaoTokenResponse;
 import com.example.wini.infra.kakao.dto.KakaoUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -18,7 +17,6 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
-@Profile("!test")
 @Component
 @RequiredArgsConstructor
 public class KakaoClient {

--- a/src/main/java/com/example/wini/infra/kakao/client/KakaoClient.java
+++ b/src/main/java/com/example/wini/infra/kakao/client/KakaoClient.java
@@ -1,0 +1,83 @@
+package com.example.wini.infra.kakao.client;
+
+import static com.example.wini.global.common.constant.OauthConstants.KAKAO_BASE_URL;
+import static com.example.wini.global.error.exception.ErrorCode.KAKAO_TOKEN_ISSUANCE_FAILED;
+
+import com.example.wini.domain.auth.dto.common.OauthMemberInfo;
+import com.example.wini.global.error.exception.CustomException;
+import com.example.wini.infra.kakao.dto.KakaoTokenResponse;
+import com.example.wini.infra.kakao.dto.KakaoUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoClient {
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    private final RestClient restClient;
+
+    public String getAuthorizationCodeUri() {
+        return KAKAO_BASE_URL + "/oauth/authorize" + "?response_type=code"
+                + "&client_id=" + clientId
+                + "&redirect_uri=" + redirectUri;
+    }
+
+    public String getAccessToken(String authCode) {
+        MultiValueMap<String, String> bodyData = createTokenRequestBody(authCode);
+        try {
+            KakaoTokenResponse response = restClient
+                    .post()
+                    .uri(KAKAO_BASE_URL + "/oauth/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(bodyData)
+                    .retrieve()
+                    .body(KakaoTokenResponse.class);
+
+            if (response == null || response.accessToken() == null) {
+                throw new CustomException(KAKAO_TOKEN_ISSUANCE_FAILED);
+            }
+
+            return response.accessToken();
+        } catch (Exception e) {
+            throw new CustomException(KAKAO_TOKEN_ISSUANCE_FAILED);
+        }
+    }
+
+    private MultiValueMap<String, String> createTokenRequestBody(String authCode) {
+        MultiValueMap<String, String> bodyData = new LinkedMultiValueMap<>();
+        bodyData.add("grant_type", "authorization_code");
+        bodyData.add("client_id", clientId);
+        bodyData.add("redirect_uri", redirectUri);
+        bodyData.add("code", authCode);
+        return bodyData;
+    }
+
+    public OauthMemberInfo getMemberInfo(String accessToken) {
+        KakaoUser kakaoUser = restClient
+                .get()
+                .uri("https://kapi.kakao.com/v2/user/me")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+                    throw new RuntimeException(
+                            "[KakaoClient] 카카오 사용자 정보 요청에 실패하였습니다. HTTP Status: " + res.getStatusCode());
+                })
+                .body(KakaoUser.class);
+
+        return OauthMemberInfo.from(kakaoUser);
+    }
+}

--- a/src/main/java/com/example/wini/infra/kakao/client/KakaoClient.java
+++ b/src/main/java/com/example/wini/infra/kakao/client/KakaoClient.java
@@ -2,12 +2,15 @@ package com.example.wini.infra.kakao.client;
 
 import static com.example.wini.global.common.constant.OauthConstants.KAKAO_BASE_URL;
 import static com.example.wini.global.error.exception.ErrorCode.KAKAO_TOKEN_ISSUANCE_FAILED;
+import static com.example.wini.global.error.exception.ErrorCode.KAKAO_USERINFO_FETCH_FAILED;
 
 import com.example.wini.domain.auth.dto.common.OauthMemberInfo;
 import com.example.wini.global.error.exception.CustomException;
 import com.example.wini.infra.kakao.dto.KakaoTokenResponse;
 import com.example.wini.infra.kakao.dto.KakaoUser;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
@@ -17,6 +20,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KakaoClient {
@@ -73,8 +77,12 @@ public class KakaoClient {
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
-                    throw new RuntimeException(
-                            "[KakaoClient] 카카오 사용자 정보 요청에 실패하였습니다. HTTP Status: " + res.getStatusCode());
+                    String errorMessage = new String(res.getBody().readAllBytes(), StandardCharsets.UTF_8);
+                    log.error(
+                            "[KakaoClient] 카카오 사용자 정보 요청에 실패하였습니다. HTTP Status: {}, Body: {}",
+                            res.getStatusCode(),
+                            errorMessage);
+                    throw new CustomException(KAKAO_USERINFO_FETCH_FAILED);
                 })
                 .body(KakaoUser.class);
 

--- a/src/main/java/com/example/wini/infra/kakao/client/KakaoClient.java
+++ b/src/main/java/com/example/wini/infra/kakao/client/KakaoClient.java
@@ -9,6 +9,7 @@ import com.example.wini.infra.kakao.dto.KakaoTokenResponse;
 import com.example.wini.infra.kakao.dto.KakaoUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -17,6 +18,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
+@Profile("!test")
 @Component
 @RequiredArgsConstructor
 public class KakaoClient {

--- a/src/main/java/com/example/wini/infra/kakao/dto/KakaoAccount.java
+++ b/src/main/java/com/example/wini/infra/kakao/dto/KakaoAccount.java
@@ -1,0 +1,3 @@
+package com.example.wini.infra.kakao.dto;
+
+public record KakaoAccount(KakaoProfile profile) {}

--- a/src/main/java/com/example/wini/infra/kakao/dto/KakaoProfile.java
+++ b/src/main/java/com/example/wini/infra/kakao/dto/KakaoProfile.java
@@ -1,0 +1,5 @@
+package com.example.wini.infra.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoProfile(@JsonProperty("profile_image_url") String profileImageUrl, String nickname) {}

--- a/src/main/java/com/example/wini/infra/kakao/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/example/wini/infra/kakao/dto/KakaoTokenResponse.java
@@ -1,0 +1,5 @@
+package com.example.wini.infra.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoTokenResponse(@JsonProperty("access_token") String accessToken) {}

--- a/src/main/java/com/example/wini/infra/kakao/dto/KakaoUser.java
+++ b/src/main/java/com/example/wini/infra/kakao/dto/KakaoUser.java
@@ -1,0 +1,5 @@
+package com.example.wini.infra.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUser(Long id, @JsonProperty("kakao_account") KakaoAccount kakaoAccount) {}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,3 +14,6 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 30MB
+
+cors:
+  allowed-origins: ${ALLOWED_ORIGINS}

--- a/src/main/resources/application-jwt.yml
+++ b/src/main/resources/application-jwt.yml
@@ -1,0 +1,12 @@
+spring:
+  config:
+    activate:
+      on-profile: "jwt"
+jwt:
+  issuer: ${JWT_ISSUER}
+  accessToken:
+    secret-key: ${JWT_ACCESS_TOKEN_SECRET_KEY}
+    expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME}
+  refreshToken:
+    secret-key: ${JWT_REFRESH_TOKEN_SECRET_KEY}
+    expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME}

--- a/src/main/resources/application-jwt.yml
+++ b/src/main/resources/application-jwt.yml
@@ -10,3 +10,6 @@ jwt:
   refreshToken:
     secret-key: ${JWT_REFRESH_TOKEN_SECRET_KEY}
     expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME}
+
+cors:
+  allowed-origins: ${ALLOWED_ORIGINS}

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -1,0 +1,9 @@
+spring:
+  config:
+    activate:
+      on-profile: "oauth"
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-key: ${KAKAO_CLIENT_KEY}
+  redirect-uri: ${KAKAO_REDIRECT_URI}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,10 @@ spring:
       test: "h2"
     include:
       - swagger
+      - oauth
+      - jwt
 
   application:
     name: wini
+  config:
+    import: optional:file:.env[.properties]

--- a/src/test/java/com/example/wini/WiniApplicationTests.java
+++ b/src/test/java/com/example/wini/WiniApplicationTests.java
@@ -1,11 +1,14 @@
 package com.example.wini;
 
+import com.example.wini.global.config.TestConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Import(TestConfig.class)
 class WiniApplicationTests {
 
     @Test

--- a/src/test/java/com/example/wini/global/config/TestConfig.java
+++ b/src/test/java/com/example/wini/global/config/TestConfig.java
@@ -1,0 +1,20 @@
+package com.example.wini.global.config;
+
+import com.example.wini.infra.kakao.client.KakaoClient;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.client.RestClient;
+
+@TestConfiguration
+@Profile("test")
+public class TestConfig {
+    @MockBean
+    private RestClient restClient;
+
+    @Bean
+    public KakaoClient kakaoClient() {
+        return new KakaoClient(restClient);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,3 @@
+kakao:
+  client-id: "test-kakao-client-id"
+  redirect-uri: "http://localhost:8080/test/callback"

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,3 +1,14 @@
 kakao:
   client-id: "test-kakao-client-id"
   redirect-uri: "http://localhost:8080/test/callback"
+jwt:
+  issuer: test-issure
+  accessToken:
+    secret-key: aaaassssbbbbcccceeeeffffggggqqqqrrrrccccaaaa
+    expiration-time: 3400
+  refreshToken:
+    secret-key: aaaassssbbbbcccceeeeffffggggqqqqrrrrccccaaaa
+    expiration-time: 16000
+
+cors:
+  allowed-origins: http://localhost:8080


### PR DESCRIPTION
## 🌱 관련 이슈
- close #39 

## 📌 작업 내용 및 특이사항
- JWT 적용
- 시큐리티 적용
- 카카오 로그인 API 구현
- 토큰 재발급 API 구현

## 📝 참고사항
- 카카오 인증 코드를 얻기 위해 리다이렉트 uri가 추가되었습니다. 
- 토큰 재발급 API가 추가되었습니다. 
- 제가 맡았던 방과 회원 쪽은 시큐리티를 통해 회원정보를 가져오는 걸로 수정했습니다. 노트 쪽도 해보려 했으나 생각보다 로직이 추가될 것 같아 건들지는 못했습니다. 
- AuthMember로 Member 객체를 조회할 수 있는 MemberUtil.getMember 메서드를 추가했습니다. 

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 카카오 OAuth 로그인(로그인 URL·콜백), 액세스·리프레시 토큰 발급·재발급, 로그아웃(토큰 블랙리스트 포함) 지원
  - JWT 생성·검증·필터·엔트리포인트·관련 오류 코드·인증 멤버(AuthMember) 추가
  - 카카오 연동 HTTP 클라이언트/DTO, 리프레시 토큰 엔티티·저장소·토큰 서비스, 캐시 기반 토큰 블랙리스트 및 캐시 설정 추가

- **Refactor**
  - 회원/방/알림/푸시 토큰 API를 인증된 사용자 컨텍스트 기반으로 전환 (MemberUtil 도입)

- **Chores**
  - 보안·JWT·캐시(Caffeine)·HTTP 클라이언트 의존성 추가
  - CI에 테스트·문제 리포트 업로드 단계 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->