### PR TITLE
feat: 나를 대표하는 키워드 조회

### DIFF
--- a/src/main/java/com/example/wini/domain/log/controller/LogController.java
+++ b/src/main/java/com/example/wini/domain/log/controller/LogController.java
@@ -27,6 +27,6 @@ public class LogController {
     @GetMapping("/keywords")
     @Operation(summary = "나를 대표하는 키워드", description = "최근 30일간 가장 많이 받은 긍정과 부정 카테고리를 반환합니다.")
     public KeywordResponse getKeywords() {
-        return logService.getMyKeywords();
+        return logService.getTopActionCategoriesInLast30Days();
     }
 }

--- a/src/main/java/com/example/wini/domain/log/controller/LogController.java
+++ b/src/main/java/com/example/wini/domain/log/controller/LogController.java
@@ -1,5 +1,6 @@
 package com.example.wini.domain.log.controller;
 
+import com.example.wini.domain.log.dto.response.KeywordResponse;
 import com.example.wini.domain.log.dto.response.StatisticsResponse;
 import com.example.wini.domain.log.service.LogService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,5 +22,11 @@ public class LogController {
     @Operation(summary = "주간 통계 조회", description = "주간 통계 결과를 반환합니다.")
     public StatisticsResponse getStatistics() {
         return logService.getWeeklyStatistics();
+    }
+
+    @GetMapping("/keywords")
+    @Operation(summary = "나를 대표하는 키워드", description = "최근 30일간 가장 많이 받은 긍정과 부정 카테고리를 반환합니다.")
+    public KeywordResponse getKeywords() {
+        return logService.getMyKeywords();
     }
 }

--- a/src/main/java/com/example/wini/domain/log/dto/response/KeywordResponse.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/KeywordResponse.java
@@ -1,0 +1,11 @@
+package com.example.wini.domain.log.dto.response;
+
+import com.example.wini.domain.template.domain.ActionCategory;
+import com.example.wini.domain.template.dto.response.ActionCategoryResponse;
+
+public record KeywordResponse(
+        ActionCategoryResponse positiveActionCategory, ActionCategoryResponse negativeActionCategory) {
+    public static KeywordResponse from(ActionCategory positive, ActionCategory negative) {
+        return new KeywordResponse(ActionCategoryResponse.from(positive), ActionCategoryResponse.from(negative));
+    }
+}

--- a/src/main/java/com/example/wini/domain/log/service/LogService.java
+++ b/src/main/java/com/example/wini/domain/log/service/LogService.java
@@ -34,7 +34,7 @@ public class LogService {
     }
 
     @Transactional(readOnly = true)
-    public KeywordResponse getMyKeywords() {
+    public KeywordResponse getTopActionCategoriesInLast30Days() {
         // TODO : 인가받은 사용자의 노트로 필터링 필요
         ActionCategory positive =
                 noteRepository.findTopActionCategoryInLast30DaysByMemberIdAndEmotionType(1L, EmotionType.POSITIVE);

--- a/src/main/java/com/example/wini/domain/log/service/LogService.java
+++ b/src/main/java/com/example/wini/domain/log/service/LogService.java
@@ -2,10 +2,13 @@ package com.example.wini.domain.log.service;
 
 import static com.example.wini.global.error.exception.ErrorCode.*;
 
+import com.example.wini.domain.log.dto.response.KeywordResponse;
 import com.example.wini.domain.log.dto.response.StatisticsResponse;
 import com.example.wini.domain.note.repository.NoteRepository;
 import com.example.wini.domain.room.entity.Room;
 import com.example.wini.domain.room.repository.RoomRepository;
+import com.example.wini.domain.template.domain.ActionCategory;
+import com.example.wini.domain.template.domain.EmotionType;
 import com.example.wini.global.error.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,5 +31,16 @@ public class LogService {
         Room room = roomRepository.findOpenRoomByMemberId(1L).orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
 
         return StatisticsResponse.of(notesSentThisWeek, notesReceivedThisWeek, room.getCreatedAt());
+    }
+
+    @Transactional(readOnly = true)
+    public KeywordResponse getMyKeywords() {
+        // TODO : 인가받은 사용자의 노트로 필터링 필요
+        ActionCategory positive =
+                noteRepository.findTopActionCategoryInLast30DaysByMemberIdAndEmotionType(1L, EmotionType.POSITIVE);
+        ActionCategory negative =
+                noteRepository.findTopActionCategoryInLast30DaysByMemberIdAndEmotionType(1L, EmotionType.NEGATIVE);
+
+        return KeywordResponse.from(positive, negative);
     }
 }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
@@ -1,6 +1,8 @@
 package com.example.wini.domain.note.repository;
 
 import com.example.wini.domain.note.domain.Note;
+import com.example.wini.domain.template.domain.ActionCategory;
+import com.example.wini.domain.template.domain.EmotionType;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,6 +12,8 @@ public interface NoteCustomRepository {
     List<Note> findLatestNotes();
 
     List<Note> findSavedNotes();
+
+    ActionCategory findTopActionCategoryInLast30DaysByMemberIdAndEmotionType(Long memberId, EmotionType emotionType);
 
     Long countTodayNotes();
 

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -1,8 +1,12 @@
 package com.example.wini.domain.note.repository;
 
 import static com.example.wini.domain.note.domain.QNote.note;
+import static com.example.wini.domain.template.domain.QAction.action;
+import static com.example.wini.domain.template.domain.QActionCategory.actionCategory;
 
 import com.example.wini.domain.note.domain.Note;
+import com.example.wini.domain.template.domain.ActionCategory;
+import com.example.wini.domain.template.domain.EmotionType;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.DayOfWeek;
@@ -47,6 +51,23 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     }
 
     @Override
+    public ActionCategory findTopActionCategoryInLast30DaysByMemberIdAndEmotionType(
+            Long memberId, EmotionType emotionType) {
+        return queryFactory
+                .select(actionCategory)
+                .from(note)
+                .join(note.action, action)
+                .join(action.actionCategory, actionCategory)
+                .where(isReceiver(memberId)
+                        .and(isCreatedInLast30Days())
+                        .and(actionCategory.emotionType.eq(emotionType)))
+                .groupBy(actionCategory.id)
+                .orderBy(actionCategory.id.count().desc(), note.createdAt.max().desc())
+                .limit(1)
+                .fetchOne();
+    }
+
+    @Override
     public Long countTodayNotes() {
         return queryFactory.select(note.count()).from(note).where(isToday()).fetchFirst();
     }
@@ -86,6 +107,10 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         LocalDateTime startOfNextWeek =
                 LocalDate.now().with(TemporalAdjusters.next(DayOfWeek.MONDAY)).atStartOfDay();
         return note.createdAt.goe(startOfWeek).and(note.createdAt.lt(startOfNextWeek));
+    }
+
+    private BooleanExpression isCreatedInLast30Days() {
+        return note.createdAt.goe(LocalDateTime.now().minusDays(30));
     }
 
     private BooleanExpression isSender(Long memberId) {

--- a/src/main/java/com/example/wini/domain/template/controller/TemplateController.java
+++ b/src/main/java/com/example/wini/domain/template/controller/TemplateController.java
@@ -33,7 +33,7 @@ public class TemplateController {
 
     @GetMapping("/actions")
     @Operation(summary = "행동 리스트 조회", description = "감정 유형을 쿼리로 받아 행동 목록을 카테고리로 분류하여 반환합니다.")
-    public List<ActionCategoryResponse> getActionsByEmotionType(
+    public List<ActionCategoryWithActionsResponse> getActionsByEmotionType(
             @RequestParam(value = "emotionType") @NotBlank String emotionType) {
         return actionService.findAllActionsGroupedByCategoryByEmotionType(emotionType);
     }

--- a/src/main/java/com/example/wini/domain/template/dto/response/ActionCategoryResponse.java
+++ b/src/main/java/com/example/wini/domain/template/dto/response/ActionCategoryResponse.java
@@ -1,14 +1,10 @@
 package com.example.wini.domain.template.dto.response;
 
-import com.example.wini.domain.template.domain.Action;
 import com.example.wini.domain.template.domain.ActionCategory;
-import java.util.List;
 
-public record ActionCategoryResponse(Long id, String emotionType, String name, List<ActionResponse> actions) {
-    public static ActionCategoryResponse from(ActionCategory category, List<Action> actions) {
-        List<ActionResponse> actionResponses =
-                actions.stream().map(ActionResponse::from).toList();
+public record ActionCategoryResponse(Long id, String emotionType, String name) {
+    public static ActionCategoryResponse from(ActionCategory category) {
         return new ActionCategoryResponse(
-                category.getId(), category.getEmotionType().getValue(), category.getName(), actionResponses);
+                category.getId(), category.getEmotionType().getValue(), category.getName());
     }
 }

--- a/src/main/java/com/example/wini/domain/template/dto/response/ActionCategoryWithActionsResponse.java
+++ b/src/main/java/com/example/wini/domain/template/dto/response/ActionCategoryWithActionsResponse.java
@@ -1,0 +1,15 @@
+package com.example.wini.domain.template.dto.response;
+
+import com.example.wini.domain.template.domain.Action;
+import com.example.wini.domain.template.domain.ActionCategory;
+import java.util.List;
+
+public record ActionCategoryWithActionsResponse(
+        Long id, String emotionType, String name, List<ActionResponse> actions) {
+    public static ActionCategoryWithActionsResponse from(ActionCategory category, List<Action> actions) {
+        List<ActionResponse> actionResponses =
+                actions.stream().map(ActionResponse::from).toList();
+        return new ActionCategoryWithActionsResponse(
+                category.getId(), category.getEmotionType().getValue(), category.getName(), actionResponses);
+    }
+}

--- a/src/main/java/com/example/wini/domain/template/service/ActionService.java
+++ b/src/main/java/com/example/wini/domain/template/service/ActionService.java
@@ -3,7 +3,7 @@ package com.example.wini.domain.template.service;
 import com.example.wini.domain.template.domain.Action;
 import com.example.wini.domain.template.domain.ActionCategory;
 import com.example.wini.domain.template.domain.EmotionType;
-import com.example.wini.domain.template.dto.response.ActionCategoryResponse;
+import com.example.wini.domain.template.dto.response.ActionCategoryWithActionsResponse;
 import com.example.wini.domain.template.repository.action.ActionRepository;
 import java.util.Comparator;
 import java.util.List;
@@ -21,12 +21,12 @@ public class ActionService {
     private final ActionRepository actionRepository;
 
     @Transactional(readOnly = true)
-    public List<ActionCategoryResponse> findAllActionsGroupedByCategoryByEmotionType(String emotionType) {
+    public List<ActionCategoryWithActionsResponse> findAllActionsGroupedByCategoryByEmotionType(String emotionType) {
         EmotionType type = EmotionType.from(emotionType);
         Map<ActionCategory, List<Action>> actionsMap = actionRepository.findActionsGroupedByCategoryByEmotionType(type);
         return actionsMap.entrySet().stream()
                 .sorted(Comparator.comparing(entry -> entry.getKey().getId()))
-                .map(entry -> ActionCategoryResponse.from(entry.getKey(), entry.getValue()))
+                .map(entry -> ActionCategoryWithActionsResponse.from(entry.getKey(), entry.getValue()))
                 .toList();
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #43

## 📌 작업 내용 및 특이사항
- 나를 대표하는 키워드 조회 API 구현
  - 최근 30일간 받은 쪽지 중 가장 많이 차지한 카테고리 (긍정, 부정) 조회

## 📝 참고사항
- 기존의 행동 카테고리 응답 dto 이름을 변경했습니다. (action 포함된 응답과 포함되지 않은 응답 분리)

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 지난 30일 기준 긍/부정 상위 행동 카테고리를 제공하는 키워드 조회 엔드포인트가 추가되었습니다.
  - 템플릿 조회 응답에 각 카테고리의 액션 목록이 포함되어 더 풍부한 정보를 제공합니다.

- Refactor
  - 템플릿 조회 API의 응답 스키마가 변경되었습니다(카테고리 기본 정보와 액션 목록 분리). 클라이언트 파싱 로직 업데이트가 필요할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->