### PR TITLE
refactor: 템플릿 도메인 텍스트 길이 변경

### DIFF
--- a/src/main/java/com/example/wini/domain/template/domain/Action.java
+++ b/src/main/java/com/example/wini/domain/template/domain/Action.java
@@ -20,7 +20,7 @@ public class Action extends BaseEntity {
     @JoinColumn(name = "action_category_id")
     private ActionCategory actionCategory;
 
-    @Column(length = 30, nullable = false)
+    @Column(length = 50, nullable = false)
     private String text;
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/example/wini/domain/template/domain/Closing.java
+++ b/src/main/java/com/example/wini/domain/template/domain/Closing.java
@@ -20,7 +20,7 @@ public class Closing extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private EmotionType emotionType;
 
-    @Column(length = 30, nullable = false)
+    @Column(length = 50, nullable = false)
     private String text;
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/example/wini/domain/template/domain/Promise.java
+++ b/src/main/java/com/example/wini/domain/template/domain/Promise.java
@@ -20,7 +20,7 @@ public class Promise extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private EmotionType emotionType;
 
-    @Column(length = 30, nullable = false)
+    @Column(length = 50, nullable = false)
     private String text;
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/example/wini/domain/template/domain/Situation.java
+++ b/src/main/java/com/example/wini/domain/template/domain/Situation.java
@@ -20,7 +20,7 @@ public class Situation extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private EmotionType emotionType;
 
-    @Column(length = 30, nullable = false)
+    @Column(length = 50, nullable = false)
     private String text;
 
     @Builder(access = AccessLevel.PRIVATE)


### PR DESCRIPTION
## 🌱 관련 이슈
- close #71 

## 📌 작업 내용 및 특이사항
- 템플릿 도메인 텍스트 길이 변경

## 📝 참고사항
- 문제가 발생하지 않은 템플릿 도메인들도 혹시 모를 상황을 대비해 50으로 늘렸습니다. 

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 템플릿 구성 요소(상황, 약속, 행동, 마무리)의 텍스트 입력 최대 길이를 30자에서 50자로 확대하여 더 긴 문구 작성·저장을 지원합니다.
  * UI 입력 제한이 완화되어 잘림 현상이 줄고, 저장 시 길이 제한 관련 오류 발생 가능성이 낮아집니다.
  * 긴 설명, 다국어, 이모지 등을 포함한 문구 작성에 유리하며 기존 데이터와 동작에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->