### PR TITLE
feat: 알림 전송 시 엔티티ID 정보 추가

### DIFF
--- a/src/main/java/com/example/wini/domain/note/controller/NoteController.java
+++ b/src/main/java/com/example/wini/domain/note/controller/NoteController.java
@@ -40,7 +40,7 @@ public class NoteController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "쪽지 생성", description = "사용자가 쪽지를 생성합니다.")
-    public NoteResponse createNote(@Valid @ModelAttribute NoteCreateRequest request) {
+    public NoteResponse createNote(@Valid @RequestBody NoteCreateRequest request) {
         return noteService.createNote(request);
     }
 

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -115,7 +115,7 @@ public class NoteService {
     }
 
     private void notifyRoommateOfNewNote(Long mateMemberId) {
-        NotificationEvent event = NotificationEvent.from(mateMemberId, NotificationType.NEW_ROOMMATE);
+        NotificationEvent event = NotificationEvent.from(mateMemberId, NotificationType.NEW_NOTE);
         eventPublisher.publishEvent(event);
     }
 }

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -2,10 +2,17 @@ package com.example.wini.domain.note.service;
 
 import static com.example.wini.global.error.exception.ErrorCode.*;
 
+import com.example.wini.domain.common.util.MemberUtil;
+import com.example.wini.domain.member.domain.Member;
+import com.example.wini.domain.member.repository.MemberRepository;
 import com.example.wini.domain.note.domain.Note;
 import com.example.wini.domain.note.dto.request.NoteCreateRequest;
 import com.example.wini.domain.note.dto.response.NoteResponse;
 import com.example.wini.domain.note.repository.NoteRepository;
+import com.example.wini.domain.notification.domain.NotificationType;
+import com.example.wini.domain.notification.event.NotificationEvent;
+import com.example.wini.domain.room.entity.Room;
+import com.example.wini.domain.room.repository.RoomRepository;
 import com.example.wini.domain.template.domain.*;
 import com.example.wini.domain.template.repository.action.ActionRepository;
 import com.example.wini.domain.template.repository.closing.ClosingRepository;
@@ -16,6 +23,7 @@ import com.example.wini.global.error.exception.CustomException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +38,10 @@ public class NoteService {
     private final SituationRepository situationRepository;
     private final PromiseRepository promiseRepository;
     private final ClosingRepository closingRepository;
+    private final MemberRepository memberRepository;
+    private final RoomRepository roomRepository;
+    private final MemberUtil memberUtil;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public NoteResponse findNoteById(Long noteId) {
@@ -54,8 +66,14 @@ public class NoteService {
 
     @Transactional(readOnly = false)
     public NoteResponse createNote(NoteCreateRequest request) {
-        Note note = buildNewNote(request);
+        Member me = memberUtil.getCurrentMember();
+        Member mate = memberRepository
+                .findRoommateByMemberId(me.getId())
+                .orElseThrow(() -> new CustomException(MATE_NOT_FOUND));
+
+        Note note = buildNewNote(request, me, mate);
         noteRepository.save(note);
+        notifyRoommateOfNewNote(mate.getId());
         return NoteResponse.from(note);
     }
 
@@ -67,8 +85,10 @@ public class NoteService {
         return NoteResponse.from(note);
     }
 
-    private Note buildNewNote(NoteCreateRequest request) {
-        // TODO : 인가받은 사용자로 송신자, 수신자 판단
+    private Note buildNewNote(NoteCreateRequest request, Member me, Member mate) {
+        Room room = roomRepository
+                .findOpenRoomByMemberId(me.getId())
+                .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
         Emotion emotion = emotionRepository
                 .findById(request.emotionId())
                 .orElseThrow(() -> new CustomException(EMOTION_NOT_FOUND));
@@ -85,11 +105,17 @@ public class NoteService {
                 .orElseThrow(() -> new CustomException(CLOSING_NOT_FOUND));
         int nextSequence = getNextSequence();
 
-        return Note.create(1L, 2L, 1L, emotion, action, situation, promise, closing, nextSequence);
+        return Note.create(
+                me.getId(), mate.getId(), room.getId(), emotion, action, situation, promise, closing, nextSequence);
     }
 
     private int getNextSequence() {
         // TODO : 인가받은 사용자의 노트로 필터링 필요
         return noteRepository.countTodayNotes().intValue() + 1;
+    }
+
+    private void notifyRoommateOfNewNote(Long mateMemberId) {
+        NotificationEvent event = NotificationEvent.from(mateMemberId, NotificationType.NEW_ROOMMATE);
+        eventPublisher.publishEvent(event);
     }
 }

--- a/src/main/java/com/example/wini/domain/notification/event/NotificationEvent.java
+++ b/src/main/java/com/example/wini/domain/notification/event/NotificationEvent.java
@@ -1,10 +1,15 @@
 package com.example.wini.domain.notification.event;
 
 import com.example.wini.domain.notification.domain.NotificationType;
+import java.util.Optional;
 
-public record NotificationEvent(Long recipientId, NotificationType notificationType) {
+public record NotificationEvent(Long recipientId, NotificationType notificationType, Optional<Long> entityId) {
 
     public static NotificationEvent from(Long recipientId, NotificationType notificationType) {
-        return new NotificationEvent(recipientId, notificationType);
+        return new NotificationEvent(recipientId, notificationType, Optional.empty());
+    }
+
+    public static NotificationEvent from(Long recipientId, NotificationType notificationType, Long id) {
+        return new NotificationEvent(recipientId, notificationType, Optional.of(id));
     }
 }

--- a/src/main/java/com/example/wini/domain/notification/event/NotificationEventListener.java
+++ b/src/main/java/com/example/wini/domain/notification/event/NotificationEventListener.java
@@ -17,6 +17,6 @@ public class NotificationEventListener {
     @TransactionalEventListener
     @Async("notificationExecutor")
     public void handleNotificationEvent(NotificationEvent event) {
-        notificationSender.send(event.recipientId(), event.notificationType());
+        notificationSender.send(event);
     }
 }

--- a/src/main/java/com/example/wini/domain/notification/sender/NotificationSender.java
+++ b/src/main/java/com/example/wini/domain/notification/sender/NotificationSender.java
@@ -1,8 +1,8 @@
 package com.example.wini.domain.notification.sender;
 
-import com.example.wini.domain.notification.domain.NotificationType;
+import com.example.wini.domain.notification.event.NotificationEvent;
 
 public interface NotificationSender {
 
-    void send(Long recipientId, NotificationType notificationType);
+    void send(NotificationEvent event);
 }

--- a/src/main/java/com/example/wini/infra/fcm/client/FcmClient.java
+++ b/src/main/java/com/example/wini/infra/fcm/client/FcmClient.java
@@ -1,7 +1,7 @@
 package com.example.wini.infra.fcm.client;
 
 import com.example.wini.domain.notification.domain.FirebaseToken;
-import com.example.wini.domain.notification.domain.NotificationType;
+import com.example.wini.domain.notification.event.NotificationEvent;
 import com.example.wini.domain.notification.repository.FirebaseTokenRepository;
 import com.example.wini.domain.notification.sender.NotificationSender;
 import com.example.wini.infra.fcm.converter.FcmMessageConverter;
@@ -29,19 +29,20 @@ public class FcmClient implements NotificationSender {
 
     @Override
     @Transactional
-    public void send(Long recipientId, NotificationType notificationType) {
-        List<FirebaseToken> firebaseTokens = firebaseTokenRepository.findAllByMember_Id(recipientId);
+    public void send(NotificationEvent event) {
+        List<FirebaseToken> firebaseTokens = firebaseTokenRepository.findAllByMember_Id(event.recipientId());
 
         if (firebaseTokens.isEmpty()) {
-            log.info("[FcmClient] 알림 발송 대상 없음 - memberId: {}", recipientId);
+            log.info("[FcmClient] 알림 발송 대상 없음 - memberId: {}", event.recipientId());
             return;
         }
 
-        firebaseTokens.forEach(firebaseToken -> pushNotification(firebaseToken, notificationType));
+        firebaseTokens.forEach(firebaseToken -> pushNotification(firebaseToken, event));
     }
 
-    private void pushNotification(FirebaseToken firebaseToken, NotificationType notificationType) {
-        FcmMessageRequest request = FcmMessageRequest.from(firebaseToken.getToken(), notificationType);
+    private void pushNotification(FirebaseToken firebaseToken, NotificationEvent event) {
+        FcmMessageRequest request =
+                FcmMessageRequest.from(firebaseToken.getToken(), event.notificationType(), event.entityId());
         Message message = fcmMessageConverter.convert(request);
         try {
             firebaseMessaging.send(message);

--- a/src/main/java/com/example/wini/infra/fcm/converter/FcmMessageConverter.java
+++ b/src/main/java/com/example/wini/infra/fcm/converter/FcmMessageConverter.java
@@ -13,13 +13,18 @@ import org.springframework.stereotype.Component;
 public class FcmMessageConverter {
 
     public Message convert(FcmMessageRequest request) {
-        return Message.builder()
+        var messageBuilder = Message.builder()
                 .setNotification(createNotification(request))
                 .setToken(request.token())
                 .setApnsConfig(createApnsConfig())
                 .setAndroidConfig(createAndroidConfig())
-                .putData("type", request.type())
-                .build();
+                .putData("type", request.type());
+
+        if (request.entityId().isPresent()) {
+            messageBuilder.putData("id", String.valueOf(request.entityId().get()));
+        }
+
+        return messageBuilder.build();
     }
 
     private Notification createNotification(FcmMessageRequest request) {

--- a/src/main/java/com/example/wini/infra/fcm/dto/FcmMessageRequest.java
+++ b/src/main/java/com/example/wini/infra/fcm/dto/FcmMessageRequest.java
@@ -1,11 +1,12 @@
 package com.example.wini.infra.fcm.dto;
 
 import com.example.wini.domain.notification.domain.NotificationType;
+import java.util.Optional;
 
-public record FcmMessageRequest(String token, String title, String body, String type) {
+public record FcmMessageRequest(String token, String title, String body, String type, Optional<Long> entityId) {
 
-    public static FcmMessageRequest from(String token, NotificationType notificationType) {
+    public static FcmMessageRequest from(String token, NotificationType notificationType, Optional<Long> entityId) {
         return new FcmMessageRequest(
-                token, notificationType.getTitle(), notificationType.getBody(), notificationType.getType());
+                token, notificationType.getTitle(), notificationType.getBody(), notificationType.getType(), entityId);
     }
 }

--- a/src/test/java/com/example/wini/domain/notification/sender/TestNotificationSender.java
+++ b/src/test/java/com/example/wini/domain/notification/sender/TestNotificationSender.java
@@ -1,6 +1,6 @@
 package com.example.wini.domain.notification.sender;
 
-import com.example.wini.domain.notification.domain.NotificationType;
+import com.example.wini.domain.notification.event.NotificationEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 public class TestNotificationSender implements NotificationSender {
 
     @Override
-    public void send(Long recipientId, NotificationType notificationType) {
+    public void send(NotificationEvent event) {
         log.info("Test Event Listener 동작 성공");
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #75 

## 📌 작업 내용 및 특이사항
- 새로운 쪽지 알림 등 도메인별 알림에 도메인 ID를 FCM 메시지에 포함시켜, 프론트에서 활용하기 쉽게 개선했습니다.
- 쪽지 생성 시 알림을 발송하는 로직을 추가했습니다. 

## 📝 참고사항
- 쪽지 생성 시 알림 발송하는 메서드 적용을 위해 인증·인가를 적용했습니다. 추후 윤주님 스타일에 맞게 수정해주시면 감사하겠습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 메모 생성 시 룸메이트에게 즉시 푸시 알림이 전송됩니다.
  - 알림에 관련 엔티티 ID가 포함되어 더 풍부한 컨텍스트(예: 딥링크) 제공됩니다.
  - 메모 생성 API가 JSON 요청 본문(RequestBody)을 받도록 변경되어 클라이언트 호출 방식이 명확해졌습니다.
- Bug Fixes
  - 룸메이트 또는 오픈 룸을 찾을 수 없는 경우 더 정확한 오류가 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->