### PR TITLE
feat: 방 정보 조회

### DIFF
--- a/src/main/java/com/example/wini/domain/room/controller/RoomController.java
+++ b/src/main/java/com/example/wini/domain/room/controller/RoomController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,5 +35,11 @@ public class RoomController {
     @Operation(summary = "초대코드 입력", description = "초대코드와 연결된 방 정보를 반환합니다.")
     public RoomResponse joinRoom(@Valid @RequestBody RoomJoinRequest request) {
         return roomService.joinRoom(request);
+    }
+
+    @GetMapping("/my")
+    @Operation(summary = "방 정보 조회", description = "방 정보를 반환합니다.")
+    public RoomResponse getRoom() {
+        return roomService.searchRoom();
     }
 }

--- a/src/main/java/com/example/wini/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/wini/domain/room/service/RoomService.java
@@ -112,4 +112,12 @@ public class RoomService {
         NotificationEvent event = NotificationEvent.from(mate.getId(), NotificationType.NEW_ROOMMATE);
         eventPublisher.publishEvent(event);
     }
+
+    public RoomResponse searchRoom() {
+        Long memberId = memberUtil.getCurrentMemberId();
+        Room room =
+                roomRepository.findOpenRoomByMemberId(memberId).orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
+
+        return RoomResponse.from(room);
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #79 

## 📌 작업 내용 및 특이사항
- 방 정보 조회 API 구현

## 📝 참고사항
- 확장성을 생각해 방 초대코드 조회에서 방 정보 조회로 의미를 변경했습니다. 

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 로그인한 사용자의 현재 방 정보를 조회하는 GET API 추가 (/rooms/my). 열린 방 정보를 반환하며 방이 없으면 적절한 오류를 응답합니다.
- 문서
  - OpenAPI에 신규 엔드포인트와 응답 스펙을 추가해 API 문서를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->