### PR TITLE
feat: 감정 엔티티에 용도별 이미지 url 추가

### DIFF
--- a/src/main/java/com/example/wini/domain/template/domain/Emotion.java
+++ b/src/main/java/com/example/wini/domain/template/domain/Emotion.java
@@ -24,20 +24,47 @@ public class Emotion extends BaseEntity {
     private String text;
 
     @Column(nullable = false)
-    private String graphicUrl;
+    private String selectionImageUrl;
+
+    @Column(nullable = false)
+    private String previewImageUrl;
+
+    @Column(nullable = false)
+    private String archiveImageUrl;
+
+    @Column(nullable = false)
+    private String homeThumbnailUrl;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Emotion(EmotionType emotionType, String text, String graphicUrl) {
+    private Emotion(
+            EmotionType emotionType,
+            String text,
+            String selectionImageUrl,
+            String previewImageUrl,
+            String archiveImageUrl,
+            String homeThumbnailUrl) {
         this.emotionType = emotionType;
         this.text = text;
-        this.graphicUrl = graphicUrl;
+        this.selectionImageUrl = selectionImageUrl;
+        this.previewImageUrl = previewImageUrl;
+        this.archiveImageUrl = archiveImageUrl;
+        this.homeThumbnailUrl = homeThumbnailUrl;
     }
 
-    public static Emotion create(EmotionType emotionType, String text, String graphicUrl) {
+    public static Emotion create(
+            EmotionType emotionType,
+            String text,
+            String selectionImageUrl,
+            String previewImageUrl,
+            String archiveImageUrl,
+            String homeThumbnailUrl) {
         return Emotion.builder()
                 .emotionType(emotionType)
                 .text(text)
-                .graphicUrl(graphicUrl)
+                .selectionImageUrl(selectionImageUrl)
+                .previewImageUrl(previewImageUrl)
+                .archiveImageUrl(archiveImageUrl)
+                .homeThumbnailUrl(homeThumbnailUrl)
                 .build();
     }
 }

--- a/src/main/java/com/example/wini/domain/template/domain/EmotionType.java
+++ b/src/main/java/com/example/wini/domain/template/domain/EmotionType.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 public enum EmotionType {
     POSITIVE("positive"),
     NEGATIVE("negative"),
+    NONE("none"),
     ;
 
     private final String value;

--- a/src/main/java/com/example/wini/domain/template/dto/response/EmotionResponse.java
+++ b/src/main/java/com/example/wini/domain/template/dto/response/EmotionResponse.java
@@ -2,9 +2,22 @@ package com.example.wini.domain.template.dto.response;
 
 import com.example.wini.domain.template.domain.Emotion;
 
-public record EmotionResponse(Long id, String emotionType, String text, String graphicUrl) {
+public record EmotionResponse(
+        Long id,
+        String emotionType,
+        String text,
+        String selectionImageUrl,
+        String previewImageUrl,
+        String archiveImageUrl,
+        String homeThumbnailUrl) {
     public static EmotionResponse from(Emotion emotion) {
         return new EmotionResponse(
-                emotion.getId(), emotion.getEmotionType().getValue(), emotion.getText(), emotion.getGraphicUrl());
+                emotion.getId(),
+                emotion.getEmotionType().getValue(),
+                emotion.getText(),
+                emotion.getSelectionImageUrl(),
+                emotion.getPreviewImageUrl(),
+                emotion.getArchiveImageUrl(),
+                emotion.getHomeThumbnailUrl());
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #83

## 📌 작업 내용 및 특이사항
- 감정 엔티티에 필요한 이미지 url 필드를 용도별로 추가 
- EmotionType에 NONE 추가

## 📝 참고사항
- 각 필드에 대한 설명은 커밋 메시지로 남겨두었습니다

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 감정 항목이 단일 이미지 대신 선택/미리보기/아카이브/홈 썸네일 등 다중 이미지를 지원합니다. 화면별로 더 선명하고 적합한 이미지를 표시할 수 있습니다.
  - 감정 타입에 ‘없음(NONE)’이 추가되어 선택지가 확장되고 빈 값 처리 시 안정성이 향상됩니다.
  - 감정 정보 조회 응답에 새 이미지 필드들이 포함되어 목록, 상세, 보관함, 홈 등 다양한 뷰에서 풍부한 썸네일/미리보기를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->