### PR TITLE
feat: 쪽지 엔티티에 인증된 사용자 연결

### DIFF
--- a/src/main/java/com/example/wini/domain/log/service/LogService.java
+++ b/src/main/java/com/example/wini/domain/log/service/LogService.java
@@ -29,11 +29,11 @@ public class LogService {
     @Transactional(readOnly = true)
     public StatisticsResponse getWeeklyStatistics() {
         Member me = memberUtil.getCurrentMember();
-        Long notesSentThisWeek = noteRepository.countNotesSentThisWeek(me.getId());
-        Long notesReceivedThisWeek = noteRepository.countNotesReceivedThisWeek(me.getId());
         Room room = roomRepository
                 .findOpenRoomByMemberId(me.getId())
                 .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
+        Long notesSentThisWeek = noteRepository.countNotesSentThisWeek(me.getId(), room.getId());
+        Long notesReceivedThisWeek = noteRepository.countNotesReceivedThisWeek(me.getId(), room.getId());
 
         return StatisticsResponse.of(notesSentThisWeek, notesReceivedThisWeek, room.getCreatedAt());
     }
@@ -41,8 +41,13 @@ public class LogService {
     @Transactional(readOnly = true)
     public KeywordResponse getTopActionCategoriesInLast30Days() {
         Member me = memberUtil.getCurrentMember();
-        ActionCategory positive = noteRepository.findTopActionCategoryInLast30Days(me.getId(), EmotionType.POSITIVE);
-        ActionCategory negative = noteRepository.findTopActionCategoryInLast30Days(me.getId(), EmotionType.NEGATIVE);
+        Room room = roomRepository
+                .findOpenRoomByMemberId(me.getId())
+                .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
+        ActionCategory positive =
+                noteRepository.findTopActionCategoryInLast30Days(me.getId(), room.getId(), EmotionType.POSITIVE);
+        ActionCategory negative =
+                noteRepository.findTopActionCategoryInLast30Days(me.getId(), room.getId(), EmotionType.NEGATIVE);
 
         return KeywordResponse.from(positive, negative);
     }
@@ -50,9 +55,15 @@ public class LogService {
     @Transactional(readOnly = true)
     public GrowthResponse getActionTrendsAndWeeklyPositiveNoteCounts() {
         Member me = memberUtil.getCurrentMember();
-        ActionChange increasedPositiveAction = noteRepository.findMostIncreasedPositiveActionChange(me.getId());
-        ActionChange decreasedNegativeAction = noteRepository.findMostDecreasedNegativeActionChange(me.getId());
-        List<WeeklyNoteCount> weeklyPositiveNoteCounts = noteRepository.getWeeklyPositiveNoteCounts(me.getId());
+        Room room = roomRepository
+                .findOpenRoomByMemberId(me.getId())
+                .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
+        ActionChange increasedPositiveAction =
+                noteRepository.findMostIncreasedPositiveActionChange(me.getId(), room.getId());
+        ActionChange decreasedNegativeAction =
+                noteRepository.findMostDecreasedNegativeActionChange(me.getId(), room.getId());
+        List<WeeklyNoteCount> weeklyPositiveNoteCounts =
+                noteRepository.getWeeklyPositiveNoteCounts(me.getId(), room.getId());
 
         return GrowthResponse.from(increasedPositiveAction, decreasedNegativeAction, weeklyPositiveNoteCounts);
     }

--- a/src/main/java/com/example/wini/domain/log/service/LogService.java
+++ b/src/main/java/com/example/wini/domain/log/service/LogService.java
@@ -2,7 +2,9 @@ package com.example.wini.domain.log.service;
 
 import static com.example.wini.global.error.exception.ErrorCode.*;
 
+import com.example.wini.domain.common.util.MemberUtil;
 import com.example.wini.domain.log.dto.response.*;
+import com.example.wini.domain.member.domain.Member;
 import com.example.wini.domain.note.repository.NoteRepository;
 import com.example.wini.domain.room.entity.Room;
 import com.example.wini.domain.room.repository.RoomRepository;
@@ -22,32 +24,35 @@ public class LogService {
 
     private final NoteRepository noteRepository;
     private final RoomRepository roomRepository;
+    private final MemberUtil memberUtil;
 
     @Transactional(readOnly = true)
     public StatisticsResponse getWeeklyStatistics() {
-        // TODO : 인가받은 사용자의 노트로 필터링 필요
-        Long notesSentThisWeek = noteRepository.countNotesSentThisWeek(1L);
-        Long notesReceivedThisWeek = noteRepository.countNotesReceivedThisWeek(1L);
-        Room room = roomRepository.findOpenRoomByMemberId(1L).orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
+        Member me = memberUtil.getCurrentMember();
+        Long notesSentThisWeek = noteRepository.countNotesSentThisWeek(me.getId());
+        Long notesReceivedThisWeek = noteRepository.countNotesReceivedThisWeek(me.getId());
+        Room room = roomRepository
+                .findOpenRoomByMemberId(me.getId())
+                .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
 
         return StatisticsResponse.of(notesSentThisWeek, notesReceivedThisWeek, room.getCreatedAt());
     }
 
     @Transactional(readOnly = true)
     public KeywordResponse getTopActionCategoriesInLast30Days() {
-        // TODO : 인가받은 사용자의 노트로 필터링 필요
-        ActionCategory positive = noteRepository.findTopActionCategoryInLast30Days(1L, EmotionType.POSITIVE);
-        ActionCategory negative = noteRepository.findTopActionCategoryInLast30Days(1L, EmotionType.NEGATIVE);
+        Member me = memberUtil.getCurrentMember();
+        ActionCategory positive = noteRepository.findTopActionCategoryInLast30Days(me.getId(), EmotionType.POSITIVE);
+        ActionCategory negative = noteRepository.findTopActionCategoryInLast30Days(me.getId(), EmotionType.NEGATIVE);
 
         return KeywordResponse.from(positive, negative);
     }
 
     @Transactional(readOnly = true)
     public GrowthResponse getActionTrendsAndWeeklyPositiveNoteCounts() {
-        // TODO : 인가받은 사용자의 노트로 필터링 필요
-        ActionChange increasedPositiveAction = noteRepository.findMostIncreasedPositiveActionChange(1L);
-        ActionChange decreasedNegativeAction = noteRepository.findMostDecreasedNegativeActionChange(1L);
-        List<WeeklyNoteCount> weeklyPositiveNoteCounts = noteRepository.getWeeklyPositiveNoteCounts(1L);
+        Member me = memberUtil.getCurrentMember();
+        ActionChange increasedPositiveAction = noteRepository.findMostIncreasedPositiveActionChange(me.getId());
+        ActionChange decreasedNegativeAction = noteRepository.findMostDecreasedNegativeActionChange(me.getId());
+        List<WeeklyNoteCount> weeklyPositiveNoteCounts = noteRepository.getWeeklyPositiveNoteCounts(me.getId());
 
         return GrowthResponse.from(increasedPositiveAction, decreasedNegativeAction, weeklyPositiveNoteCounts);
     }

--- a/src/main/java/com/example/wini/domain/note/domain/Note.java
+++ b/src/main/java/com/example/wini/domain/note/domain/Note.java
@@ -105,6 +105,10 @@ public class Note extends BaseEntity {
                 .build();
     }
 
+    public void markAsRead() {
+        isSaved = true;
+    }
+
     public void markAsSaved() {
         isSaved = true;
     }

--- a/src/main/java/com/example/wini/domain/note/domain/Note.java
+++ b/src/main/java/com/example/wini/domain/note/domain/Note.java
@@ -1,6 +1,7 @@
 package com.example.wini.domain.note.domain;
 
 import com.example.wini.domain.common.BaseEntity;
+import com.example.wini.domain.member.domain.Member;
 import com.example.wini.domain.template.domain.*;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -17,12 +18,13 @@ public class Note extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // TODO : 인증인가 후 멤버 연결하기
-    @Column(nullable = false)
-    private Long senderId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id")
+    private Member sender;
 
-    @Column(nullable = false)
-    private Long receiverId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id")
+    private Member receiver;
 
     @Column(nullable = false)
     private Long roomId;
@@ -58,8 +60,8 @@ public class Note extends BaseEntity {
 
     @Builder(access = AccessLevel.PRIVATE)
     private Note(
-            Long senderId,
-            Long receiverId,
+            Member sender,
+            Member receiver,
             Long roomId,
             Emotion emotion,
             Action action,
@@ -67,8 +69,8 @@ public class Note extends BaseEntity {
             Promise promise,
             Closing closing,
             int sequence) {
-        this.senderId = senderId;
-        this.receiverId = receiverId;
+        this.sender = sender;
+        this.receiver = receiver;
         this.roomId = roomId;
         this.emotion = emotion;
         this.action = action;
@@ -81,8 +83,8 @@ public class Note extends BaseEntity {
     }
 
     public static Note create(
-            Long senderId,
-            Long receiverId,
+            Member sender,
+            Member receiver,
             Long roomId,
             Emotion emotion,
             Action action,
@@ -91,8 +93,8 @@ public class Note extends BaseEntity {
             Closing closing,
             int sequence) {
         return Note.builder()
-                .senderId(senderId)
-                .receiverId(receiverId)
+                .sender(sender)
+                .receiver(receiver)
                 .roomId(roomId)
                 .emotion(emotion)
                 .action(action)

--- a/src/main/java/com/example/wini/domain/note/domain/Note.java
+++ b/src/main/java/com/example/wini/domain/note/domain/Note.java
@@ -2,6 +2,7 @@ package com.example.wini.domain.note.domain;
 
 import com.example.wini.domain.common.BaseEntity;
 import com.example.wini.domain.member.domain.Member;
+import com.example.wini.domain.room.entity.Room;
 import com.example.wini.domain.template.domain.*;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -26,8 +27,9 @@ public class Note extends BaseEntity {
     @JoinColumn(name = "receiver_id")
     private Member receiver;
 
-    @Column(nullable = false)
-    private Long roomId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "emotion_id")
@@ -62,7 +64,7 @@ public class Note extends BaseEntity {
     private Note(
             Member sender,
             Member receiver,
-            Long roomId,
+            Room room,
             Emotion emotion,
             Action action,
             Situation situation,
@@ -71,7 +73,7 @@ public class Note extends BaseEntity {
             int sequence) {
         this.sender = sender;
         this.receiver = receiver;
-        this.roomId = roomId;
+        this.room = room;
         this.emotion = emotion;
         this.action = action;
         this.situation = situation;
@@ -85,7 +87,7 @@ public class Note extends BaseEntity {
     public static Note create(
             Member sender,
             Member receiver,
-            Long roomId,
+            Room room,
             Emotion emotion,
             Action action,
             Situation situation,
@@ -95,7 +97,7 @@ public class Note extends BaseEntity {
         return Note.builder()
                 .sender(sender)
                 .receiver(receiver)
-                .roomId(roomId)
+                .room(room)
                 .emotion(emotion)
                 .action(action)
                 .situation(situation)

--- a/src/main/java/com/example/wini/domain/note/domain/Note.java
+++ b/src/main/java/com/example/wini/domain/note/domain/Note.java
@@ -108,7 +108,7 @@ public class Note extends BaseEntity {
     }
 
     public void markAsRead() {
-        isSaved = true;
+        isRead = true;
     }
 
     public void markAsSaved() {

--- a/src/main/java/com/example/wini/domain/note/dto/response/NoteResponse.java
+++ b/src/main/java/com/example/wini/domain/note/dto/response/NoteResponse.java
@@ -23,7 +23,7 @@ public record NoteResponse(
                 note.getId(),
                 note.getSender().getId(),
                 note.getReceiver().getId(),
-                note.getRoomId(),
+                note.getRoom().getId(),
                 EmotionResponse.from(note.getEmotion()),
                 ActionResponse.from(note.getAction()),
                 SituationResponse.from(note.getSituation()),

--- a/src/main/java/com/example/wini/domain/note/dto/response/NoteResponse.java
+++ b/src/main/java/com/example/wini/domain/note/dto/response/NoteResponse.java
@@ -21,8 +21,8 @@ public record NoteResponse(
     public static NoteResponse from(Note note) {
         return new NoteResponse(
                 note.getId(),
-                note.getSenderId(),
-                note.getReceiverId(),
+                note.getSender().getId(),
+                note.getReceiver().getId(),
                 note.getRoomId(),
                 EmotionResponse.from(note.getEmotion()),
                 ActionResponse.from(note.getAction()),

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
@@ -13,7 +13,7 @@ public interface NoteCustomRepository {
 
     List<Note> findLatestNotes(Long memberId);
 
-    List<Note> findSavedNotes();
+    List<Note> findSavedNotes(Long memberId);
 
     ActionChange findMostIncreasedPositiveActionChange(Long memberId);
 

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
@@ -11,21 +11,21 @@ import java.util.Optional;
 public interface NoteCustomRepository {
     Optional<Note> findFullNote(Long noteId);
 
-    List<Note> findLatestNotes(Long memberId);
+    List<Note> findLatestNotes(Long memberId, Long roomId);
 
-    List<Note> findSavedNotes(Long memberId);
+    List<Note> findSavedNotes(Long memberId, Long roomId);
 
-    ActionChange findMostIncreasedPositiveActionChange(Long memberId);
+    ActionChange findMostIncreasedPositiveActionChange(Long memberId, Long roomId);
 
-    ActionChange findMostDecreasedNegativeActionChange(Long memberId);
+    ActionChange findMostDecreasedNegativeActionChange(Long memberId, Long roomId);
 
-    ActionCategory findTopActionCategoryInLast30Days(Long memberId, EmotionType emotionType);
+    ActionCategory findTopActionCategoryInLast30Days(Long memberId, Long roomId, EmotionType emotionType);
 
-    List<WeeklyNoteCount> getWeeklyPositiveNoteCounts(Long memberId);
+    List<WeeklyNoteCount> getWeeklyPositiveNoteCounts(Long memberId, Long roomId);
 
-    Long countNotesSentToday(Long memberId);
+    Long countNotesSentToday(Long memberId, Long roomId);
 
-    Long countNotesSentThisWeek(Long memberId);
+    Long countNotesSentThisWeek(Long memberId, Long roomId);
 
-    Long countNotesReceivedThisWeek(Long memberId);
+    Long countNotesReceivedThisWeek(Long memberId, Long roomId);
 }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
@@ -23,7 +23,7 @@ public interface NoteCustomRepository {
 
     List<WeeklyNoteCount> getWeeklyPositiveNoteCounts(Long memberId);
 
-    Long countTodayNotes();
+    Long countNotesSentToday(Long memberId);
 
     Long countNotesSentThisWeek(Long memberId);
 

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 public interface NoteCustomRepository {
     Optional<Note> findFullNote(Long noteId);
 
-    List<Note> findLatestNotes();
+    List<Note> findLatestNotes(Long memberId);
 
     List<Note> findSavedNotes();
 

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -47,8 +47,11 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     }
 
     @Override
-    public List<Note> findLatestNotes() {
-        return queryFactory.selectFrom(note).where(isCreatedLatest()).fetch();
+    public List<Note> findLatestNotes(Long memberId) {
+        return queryFactory
+                .selectFrom(note)
+                .where(isReceiver(memberId).and(isCreatedLatest()))
+                .fetch();
     }
 
     @Override

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -47,23 +47,23 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     }
 
     @Override
-    public List<Note> findLatestNotes(Long memberId) {
+    public List<Note> findLatestNotes(Long memberId, Long roomId) {
         return queryFactory
                 .selectFrom(note)
-                .where(isReceiver(memberId).and(isCreatedLatest()))
+                .where(isThisRoom(roomId).and(isReceiver(memberId)).and(isCreatedLatest()))
                 .fetch();
     }
 
     @Override
-    public List<Note> findSavedNotes(Long memberId) {
+    public List<Note> findSavedNotes(Long memberId, Long roomId) {
         return queryFactory
                 .selectFrom(note)
-                .where(isReceiver(memberId).and(isSaved()))
+                .where(isThisRoom(roomId).and(isReceiver(memberId)).and(isSaved()))
                 .fetch();
     }
 
     @Override
-    public ActionChange findMostIncreasedPositiveActionChange(Long memberId) {
+    public ActionChange findMostIncreasedPositiveActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
         NumberExpression<Long> thisMonthNotes = countThisMonthNotes(today);
         NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
@@ -74,14 +74,16 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
-                .where(isReceiver(memberId).and(actionCategory.emotionType.eq(EmotionType.POSITIVE)))
+                .where(isThisRoom(roomId)
+                        .and(isReceiver(memberId))
+                        .and(actionCategory.emotionType.eq(EmotionType.POSITIVE)))
                 .groupBy(action)
                 .orderBy(increaseCount.desc())
                 .fetchFirst();
     }
 
     @Override
-    public ActionChange findMostDecreasedNegativeActionChange(Long memberId) {
+    public ActionChange findMostDecreasedNegativeActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
         NumberExpression<Long> thisMonthNotes = countThisMonthNotes(today);
         NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
@@ -92,20 +94,23 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
-                .where(isReceiver(memberId).and(actionCategory.emotionType.eq(EmotionType.NEGATIVE)))
+                .where(isThisRoom(roomId)
+                        .and(isReceiver(memberId))
+                        .and(actionCategory.emotionType.eq(EmotionType.NEGATIVE)))
                 .groupBy(action)
                 .orderBy(decreaseCount.asc())
                 .fetchFirst();
     }
 
     @Override
-    public ActionCategory findTopActionCategoryInLast30Days(Long memberId, EmotionType emotionType) {
+    public ActionCategory findTopActionCategoryInLast30Days(Long memberId, Long roomId, EmotionType emotionType) {
         return queryFactory
                 .select(actionCategory)
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
-                .where(isReceiver(memberId)
+                .where(isThisRoom(roomId)
+                        .and(isReceiver(memberId))
                         .and(isCreatedInLast30Days())
                         .and(actionCategory.emotionType.eq(emotionType)))
                 .groupBy(actionCategory)
@@ -114,7 +119,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     }
 
     @Override
-    public List<WeeklyNoteCount> getWeeklyPositiveNoteCounts(Long memberId) {
+    public List<WeeklyNoteCount> getWeeklyPositiveNoteCounts(Long memberId, Long roomId) {
         List<WeeklyNoteCount> results = new ArrayList<>();
 
         LocalDate today = LocalDate.now();
@@ -127,7 +132,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                     .from(note)
                     .join(note.action, action)
                     .join(action.actionCategory, actionCategory)
-                    .where(isReceiver(memberId)
+                    .where(isThisRoom(roomId)
+                            .and(isReceiver(memberId))
                             .and(actionCategory.emotionType.eq(EmotionType.POSITIVE))
                             .and(isCreatedInLast7Days(endDateTime)))
                     .fetchOne();
@@ -141,29 +147,29 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     }
 
     @Override
-    public Long countNotesSentToday(Long memberId) {
+    public Long countNotesSentToday(Long memberId, Long roomId) {
         return queryFactory
                 .select(note.count())
                 .from(note)
-                .where(isSender(memberId).and(isCreatedToday()))
+                .where(isThisRoom(roomId).and(isSender(memberId)).and(isCreatedToday()))
                 .fetchFirst();
     }
 
     @Override
-    public Long countNotesSentThisWeek(Long memberId) {
+    public Long countNotesSentThisWeek(Long memberId, Long roomId) {
         return queryFactory
                 .select(note.count())
                 .from(note)
-                .where(isSender(memberId).and(isCreatedThisWeek()))
+                .where(isThisRoom(roomId).and(isSender(memberId)).and(isCreatedThisWeek()))
                 .fetchFirst();
     }
 
     @Override
-    public Long countNotesReceivedThisWeek(Long memberId) {
+    public Long countNotesReceivedThisWeek(Long memberId, Long roomId) {
         return queryFactory
                 .select(note.count())
                 .from(note)
-                .where(isReceiver(memberId).and(isCreatedThisWeek()))
+                .where(isThisRoom(roomId).and(isReceiver(memberId)).and(isCreatedThisWeek()))
                 .fetchFirst();
     }
 
@@ -227,6 +233,10 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
 
     private BooleanExpression isCreatedInLast30Days() {
         return note.createdAt.goe(LocalDateTime.now().minusDays(30));
+    }
+
+    private BooleanExpression isThisRoom(Long roomId) {
+        return note.room.id.eq(roomId);
     }
 
     private BooleanExpression isSender(Long memberId) {

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -224,10 +224,10 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     }
 
     private BooleanExpression isSender(Long memberId) {
-        return note.senderId.eq(memberId);
+        return note.sender.id.eq(memberId);
     }
 
     private BooleanExpression isReceiver(Long memberId) {
-        return note.receiverId.eq(memberId);
+        return note.receiver.id.eq(memberId);
     }
 }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -145,7 +145,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         return queryFactory
                 .select(note.count())
                 .from(note)
-                .where(isCreatedToday().and(isSender(memberId)))
+                .where(isSender(memberId).and(isCreatedToday()))
                 .fetchFirst();
     }
 
@@ -154,7 +154,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         return queryFactory
                 .select(note.count())
                 .from(note)
-                .where(isCreatedThisWeek().and(isSender(memberId)))
+                .where(isSender(memberId).and(isCreatedThisWeek()))
                 .fetchFirst();
     }
 
@@ -163,7 +163,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         return queryFactory
                 .select(note.count())
                 .from(note)
-                .where(isCreatedThisWeek().and(isReceiver(memberId)))
+                .where(isReceiver(memberId).and(isCreatedThisWeek()))
                 .fetchFirst();
     }
 

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -55,8 +55,11 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     }
 
     @Override
-    public List<Note> findSavedNotes() {
-        return queryFactory.selectFrom(note).where(note.isSaved.eq(true)).fetch();
+    public List<Note> findSavedNotes(Long memberId) {
+        return queryFactory
+                .selectFrom(note)
+                .where(isReceiver(memberId).and(isSaved()))
+                .fetch();
     }
 
     @Override
@@ -232,5 +235,9 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
 
     private BooleanExpression isReceiver(Long memberId) {
         return note.receiver.id.eq(memberId);
+    }
+
+    private BooleanExpression isSaved() {
+        return note.isSaved.eq(true);
     }
 }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -141,11 +141,11 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     }
 
     @Override
-    public Long countTodayNotes() {
+    public Long countNotesSentToday(Long memberId) {
         return queryFactory
                 .select(note.count())
                 .from(note)
-                .where(isCreatedToday())
+                .where(isCreatedToday().and(isSender(memberId)))
                 .fetchFirst();
     }
 

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -43,7 +43,7 @@ public class NoteService {
     private final MemberUtil memberUtil;
     private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional(readOnly = true)
+    @Transactional(readOnly = false)
     public NoteResponse findNoteById(Long noteId) {
         Note note = noteRepository.findFullNote(noteId).orElseThrow(() -> new CustomException(NOTE_NOT_FOUND));
         Member me = memberUtil.getCurrentMember();

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -46,7 +46,10 @@ public class NoteService {
     @Transactional(readOnly = true)
     public NoteResponse findNoteById(Long noteId) {
         Note note = noteRepository.findFullNote(noteId).orElseThrow(() -> new CustomException(NOTE_NOT_FOUND));
-        // TODO : 인가받은 사용자 확인 후 읽음 처리 필요
+        Member me = memberUtil.getCurrentMember();
+        if (note.getReceiver().equals(me)) {
+            note.markAsRead();
+        }
         return NoteResponse.from(note);
     }
 

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -112,8 +112,8 @@ public class NoteService {
     }
 
     private int getNextSequence() {
-        // TODO : 인가받은 사용자의 노트로 필터링 필요
-        return noteRepository.countTodayNotes().intValue() + 1;
+        Member me = memberUtil.getCurrentMember();
+        return noteRepository.countNotesSentToday(me.getId()).intValue() + 1;
     }
 
     private void notifyRoommateOfNewNote(Long mateMemberId) {

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -133,7 +133,7 @@ public class NoteService {
     private void validateNoteReceiver(Note note) {
         Member me = memberUtil.getCurrentMember();
         if (!note.getReceiver().equals(me)) {
-            throw new CustomException(NOTE_SENDER_MISMATCH);
+            throw new CustomException(NOTE_RECEIVER_MISMATCH);
         }
     }
 }

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -89,7 +89,7 @@ public class NoteService {
     @Transactional(readOnly = false)
     public NoteResponse saveNote(Long noteId) {
         Note note = noteRepository.findById(noteId).orElseThrow(() -> new CustomException(NOTE_NOT_FOUND));
-        validateNoteSender(note);
+        validateNoteReceiver(note);
         note.markAsSaved();
         return NoteResponse.from(note);
     }
@@ -130,9 +130,9 @@ public class NoteService {
         eventPublisher.publishEvent(event);
     }
 
-    private void validateNoteSender(Note note) {
+    private void validateNoteReceiver(Note note) {
         Member me = memberUtil.getCurrentMember();
-        if (!note.getSender().equals(me)) {
+        if (!note.getReceiver().equals(me)) {
             throw new CustomException(NOTE_SENDER_MISMATCH);
         }
     }

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -62,8 +62,8 @@ public class NoteService {
 
     @Transactional(readOnly = true)
     public List<NoteResponse> findSavedNotes() {
-        // TODO : 인가받은 사용자의 노트로 필터링 필요
-        List<Note> notes = noteRepository.findSavedNotes();
+        Member me = memberUtil.getCurrentMember();
+        List<Note> notes = noteRepository.findSavedNotes(me.getId());
         return notes.stream().map(NoteResponse::from).toList();
     }
 

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -105,8 +105,7 @@ public class NoteService {
                 .orElseThrow(() -> new CustomException(CLOSING_NOT_FOUND));
         int nextSequence = getNextSequence();
 
-        return Note.create(
-                me.getId(), mate.getId(), room.getId(), emotion, action, situation, promise, closing, nextSequence);
+        return Note.create(me, mate, room.getId(), emotion, action, situation, promise, closing, nextSequence);
     }
 
     private int getNextSequence() {

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -108,7 +108,7 @@ public class NoteService {
                 .orElseThrow(() -> new CustomException(CLOSING_NOT_FOUND));
         int nextSequence = getNextSequence();
 
-        return Note.create(me, mate, room.getId(), emotion, action, situation, promise, closing, nextSequence);
+        return Note.create(me, mate, room, emotion, action, situation, promise, closing, nextSequence);
     }
 
     private int getNextSequence() {

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -55,8 +55,8 @@ public class NoteService {
 
     @Transactional(readOnly = true)
     public List<NoteResponse> findLatestNotes() {
-        // TODO : 인가받은 사용자의 노트로 필터링 필요
-        List<Note> notes = noteRepository.findLatestNotes();
+        Member me = memberUtil.getCurrentMember();
+        List<Note> notes = noteRepository.findLatestNotes(me.getId());
         return notes.stream().map(NoteResponse::from).toList();
     }
 

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -82,8 +82,8 @@ public class NoteService {
 
     @Transactional(readOnly = false)
     public NoteResponse saveNote(Long noteId) {
-        // TODO : 인가받은 사용자로 저장 가능한지 판단
         Note note = noteRepository.findById(noteId).orElseThrow(() -> new CustomException(NOTE_NOT_FOUND));
+        validateNoteSender(note);
         note.markAsSaved();
         return NoteResponse.from(note);
     }
@@ -119,5 +119,12 @@ public class NoteService {
     private void notifyRoommateOfNewNote(Long mateMemberId) {
         NotificationEvent event = NotificationEvent.from(mateMemberId, NotificationType.NEW_NOTE);
         eventPublisher.publishEvent(event);
+    }
+
+    private void validateNoteSender(Note note) {
+        Member me = memberUtil.getCurrentMember();
+        if (!note.getSender().equals(me)) {
+            throw new CustomException(NOTE_SENDER_MISMATCH);
+        }
     }
 }

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -56,14 +56,20 @@ public class NoteService {
     @Transactional(readOnly = true)
     public List<NoteResponse> findLatestNotes() {
         Member me = memberUtil.getCurrentMember();
-        List<Note> notes = noteRepository.findLatestNotes(me.getId());
+        Room room = roomRepository
+                .findOpenRoomByMemberId(me.getId())
+                .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
+        List<Note> notes = noteRepository.findLatestNotes(me.getId(), room.getId());
         return notes.stream().map(NoteResponse::from).toList();
     }
 
     @Transactional(readOnly = true)
     public List<NoteResponse> findSavedNotes() {
         Member me = memberUtil.getCurrentMember();
-        List<Note> notes = noteRepository.findSavedNotes(me.getId());
+        Room room = roomRepository
+                .findOpenRoomByMemberId(me.getId())
+                .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
+        List<Note> notes = noteRepository.findSavedNotes(me.getId(), room.getId());
         return notes.stream().map(NoteResponse::from).toList();
     }
 
@@ -113,7 +119,10 @@ public class NoteService {
 
     private int getNextSequence() {
         Member me = memberUtil.getCurrentMember();
-        return noteRepository.countNotesSentToday(me.getId()).intValue() + 1;
+        Room room = roomRepository
+                .findOpenRoomByMemberId(me.getId())
+                .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
+        return noteRepository.countNotesSentToday(me.getId(), room.getId()).intValue() + 1;
     }
 
     private void notifyRoommateOfNewNote(Long mateMemberId) {

--- a/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
 
     // Note
     NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 마음쪽지입니다."),
+    NOTE_SENDER_MISMATCH(HttpStatus.BAD_REQUEST, "마음쪽지의 수신자가 아닙니다."),
 
     // Template
     EMOTION_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "잘못된 감정 분류입니다."),

--- a/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
@@ -46,7 +46,7 @@ public enum ErrorCode {
 
     // Note
     NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 마음쪽지입니다."),
-    NOTE_SENDER_MISMATCH(HttpStatus.BAD_REQUEST, "마음쪽지의 수신자가 아닙니다."),
+    NOTE_RECEIVER_MISMATCH(HttpStatus.BAD_REQUEST, "마음쪽지의 수신자가 아닙니다."),
 
     // Template
     EMOTION_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "잘못된 감정 분류입니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #74

## 📌 작업 내용 및 특이사항
- 쪽지 엔티티에 멤버, 방 엔티티 연결
- 쪽지 필터링할때 인증된 사용자와 현재 방 조건 추가

## 📝 참고사항
- 

## 📚 기타
- 인증된 사용자와 현재 방을 조회하는 로직이 반복적으로 나타나서 이후 리팩토링떄 하나로 묶으면 좋을 것 같습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 대시보드 통계와 트렌드가 현재 회원의 열린 방 기준으로 개인화되어 표시됩니다.
  * 수신자가 쪽지를 열람하면 자동으로 읽음 처리됩니다.
  * 수신자 검증이 추가되어, 수신자가 아닌 경우 요청이 거부되고 안내 메시지가 제공됩니다.
* 버그 수정
  * 하드코딩된 사용자 식별자 사용을 제거하여, 노트/통계가 올바른 회원·방 기준으로 집계됩니다.
* 기타
  * 성능과 일관성을 위해 내부 데이터 연동 방식을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->