### PR TITLE
feat: 저장된 쪽지에 정렬기준 추가

### DIFF
--- a/src/main/java/com/example/wini/domain/note/controller/NoteController.java
+++ b/src/main/java/com/example/wini/domain/note/controller/NoteController.java
@@ -27,9 +27,9 @@ public class NoteController {
     }
 
     @GetMapping("/latest")
-    @Operation(summary = "최근 받은 쪽지 리스트 조회", description = "24시간 내 받은 쪽지 목록을 반환합니다.")
+    @Operation(summary = "최근 받은 쪽지 리스트 조회", description = "24시간 내 받은 쪽지 목록을 최신순 정렬하여 반환합니다.")
     public List<SimpleNoteResponse> getLatestNotes() {
-        return noteService.findLatestNotes();
+        return noteService.findLatestNotesSorted();
     }
 
     @GetMapping("/saved")

--- a/src/main/java/com/example/wini/domain/note/controller/NoteController.java
+++ b/src/main/java/com/example/wini/domain/note/controller/NoteController.java
@@ -32,9 +32,11 @@ public class NoteController {
     }
 
     @GetMapping("/saved")
-    @Operation(summary = "보관된 쪽지 리스트 조회", description = "사용자가 저장한 쪽지 목록을 반환합니다.")
-    public List<NoteResponse> getSavedNotes() {
-        return noteService.findSavedNotes();
+    @Operation(summary = "보관된 쪽지 리스트 조회", description = "사용자가 저장한 쪽지 목록을 생성일시를 기준으로 정렬하여 반환합니다.")
+    public List<NoteResponse> getSavedNotes(
+            @RequestParam(value = "sort", required = false, defaultValue = "latest") String sort) {
+        // TODO : 페이징 추가 시 Pageable로 수정
+        return noteService.findSavedNotesSorted(sort);
     }
 
     @PostMapping

--- a/src/main/java/com/example/wini/domain/note/controller/NoteController.java
+++ b/src/main/java/com/example/wini/domain/note/controller/NoteController.java
@@ -2,6 +2,7 @@ package com.example.wini.domain.note.controller;
 
 import com.example.wini.domain.note.dto.request.NoteCreateRequest;
 import com.example.wini.domain.note.dto.response.NoteResponse;
+import com.example.wini.domain.note.dto.response.SimpleNoteResponse;
 import com.example.wini.domain.note.service.NoteService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,13 +28,13 @@ public class NoteController {
 
     @GetMapping("/latest")
     @Operation(summary = "최근 받은 쪽지 리스트 조회", description = "24시간 내 받은 쪽지 목록을 반환합니다.")
-    public List<NoteResponse> getLatestNotes() {
+    public List<SimpleNoteResponse> getLatestNotes() {
         return noteService.findLatestNotes();
     }
 
     @GetMapping("/saved")
     @Operation(summary = "보관된 쪽지 리스트 조회", description = "사용자가 저장한 쪽지 목록을 생성일시를 기준으로 정렬하여 반환합니다.")
-    public List<NoteResponse> getSavedNotes(
+    public List<SimpleNoteResponse> getSavedNotes(
             @RequestParam(value = "sort", required = false, defaultValue = "latest") String sort) {
         // TODO : 페이징 추가 시 Pageable로 수정
         return noteService.findSavedNotesSorted(sort);

--- a/src/main/java/com/example/wini/domain/note/domain/SortOrder.java
+++ b/src/main/java/com/example/wini/domain/note/domain/SortOrder.java
@@ -1,0 +1,25 @@
+package com.example.wini.domain.note.domain;
+
+import static com.example.wini.global.error.exception.ErrorCode.SORT_ORDER_NOT_FOUND;
+
+import com.example.wini.global.error.exception.CustomException;
+import java.util.Arrays;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SortOrder {
+    ASC("oldest"),
+    DESC("latest"),
+    ;
+
+    private final String value;
+
+    public static SortOrder from(String value) {
+        return Arrays.stream(SortOrder.values())
+                .filter(sortOrder -> sortOrder.value.equals(value))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(SORT_ORDER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/wini/domain/note/dto/response/SimpleNoteResponse.java
+++ b/src/main/java/com/example/wini/domain/note/dto/response/SimpleNoteResponse.java
@@ -1,0 +1,12 @@
+package com.example.wini.domain.note.dto.response;
+
+import com.example.wini.domain.note.domain.Note;
+import com.example.wini.domain.template.dto.response.*;
+import java.time.LocalDateTime;
+
+public record SimpleNoteResponse(Long id, EmotionResponse emotion, boolean isRead, LocalDateTime createdAt) {
+    public static SimpleNoteResponse from(Note note) {
+        return new SimpleNoteResponse(
+                note.getId(), EmotionResponse.from(note.getEmotion()), note.isRead(), note.getCreatedAt());
+    }
+}

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 public interface NoteCustomRepository {
     Optional<Note> findFullNote(Long noteId);
 
-    List<Note> findLatestNotes(Long memberId, Long roomId);
+    List<Note> findLatestNotesSortedByCreatedAtDesc(Long memberId, Long roomId);
 
     List<Note> findSavedNotesSortedByCreatedAt(Long memberId, Long roomId, SortOrder sortOrder);
 

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
@@ -3,6 +3,7 @@ package com.example.wini.domain.note.repository;
 import com.example.wini.domain.log.dto.response.ActionChange;
 import com.example.wini.domain.log.dto.response.WeeklyNoteCount;
 import com.example.wini.domain.note.domain.Note;
+import com.example.wini.domain.note.domain.SortOrder;
 import com.example.wini.domain.template.domain.ActionCategory;
 import com.example.wini.domain.template.domain.EmotionType;
 import java.util.List;
@@ -13,7 +14,7 @@ public interface NoteCustomRepository {
 
     List<Note> findLatestNotes(Long memberId, Long roomId);
 
-    List<Note> findSavedNotes(Long memberId, Long roomId);
+    List<Note> findSavedNotesSortedByCreatedAt(Long memberId, Long roomId, SortOrder sortOrder);
 
     ActionChange findMostIncreasedPositiveActionChange(Long memberId, Long roomId);
 

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -50,10 +50,11 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     }
 
     @Override
-    public List<Note> findLatestNotes(Long memberId, Long roomId) {
+    public List<Note> findLatestNotesSortedByCreatedAtDesc(Long memberId, Long roomId) {
         return queryFactory
                 .selectFrom(note)
                 .where(isThisRoom(roomId).and(isReceiver(memberId)).and(isCreatedLatest()))
+                .orderBy(note.createdAt.desc())
                 .fetch();
     }
 

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -7,8 +7,11 @@ import static com.example.wini.domain.template.domain.QActionCategory.actionCate
 import com.example.wini.domain.log.dto.response.ActionChange;
 import com.example.wini.domain.log.dto.response.WeeklyNoteCount;
 import com.example.wini.domain.note.domain.Note;
+import com.example.wini.domain.note.domain.SortOrder;
 import com.example.wini.domain.template.domain.ActionCategory;
 import com.example.wini.domain.template.domain.EmotionType;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
@@ -55,10 +58,14 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     }
 
     @Override
-    public List<Note> findSavedNotes(Long memberId, Long roomId) {
+    public List<Note> findSavedNotesSortedByCreatedAt(Long memberId, Long roomId, SortOrder sortOrder) {
+        Order order = sortOrder == SortOrder.ASC ? Order.ASC : Order.DESC;
+        OrderSpecifier<?> orderSpecifier = new OrderSpecifier<>(order, note.createdAt);
+
         return queryFactory
                 .selectFrom(note)
                 .where(isThisRoom(roomId).and(isReceiver(memberId)).and(isSaved()))
+                .orderBy(orderSpecifier)
                 .fetch();
     }
 

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -6,6 +6,7 @@ import com.example.wini.domain.common.util.MemberUtil;
 import com.example.wini.domain.member.domain.Member;
 import com.example.wini.domain.member.repository.MemberRepository;
 import com.example.wini.domain.note.domain.Note;
+import com.example.wini.domain.note.domain.SortOrder;
 import com.example.wini.domain.note.dto.request.NoteCreateRequest;
 import com.example.wini.domain.note.dto.response.NoteResponse;
 import com.example.wini.domain.note.repository.NoteRepository;
@@ -64,12 +65,13 @@ public class NoteService {
     }
 
     @Transactional(readOnly = true)
-    public List<NoteResponse> findSavedNotes() {
+    public List<NoteResponse> findSavedNotesSorted(String sort) {
         Member me = memberUtil.getCurrentMember();
         Room room = roomRepository
                 .findOpenRoomByMemberId(me.getId())
                 .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
-        List<Note> notes = noteRepository.findSavedNotes(me.getId(), room.getId());
+        SortOrder sortOrder = SortOrder.from(sort);
+        List<Note> notes = noteRepository.findSavedNotesSortedByCreatedAt(me.getId(), room.getId(), sortOrder);
         return notes.stream().map(NoteResponse::from).toList();
     }
 

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -56,12 +56,12 @@ public class NoteService {
     }
 
     @Transactional(readOnly = true)
-    public List<SimpleNoteResponse> findLatestNotes() {
+    public List<SimpleNoteResponse> findLatestNotesSorted() {
         Member me = memberUtil.getCurrentMember();
         Room room = roomRepository
                 .findOpenRoomByMemberId(me.getId())
                 .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
-        List<Note> notes = noteRepository.findLatestNotes(me.getId(), room.getId());
+        List<Note> notes = noteRepository.findLatestNotesSortedByCreatedAtDesc(me.getId(), room.getId());
         return notes.stream().map(SimpleNoteResponse::from).toList();
     }
 

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -9,6 +9,7 @@ import com.example.wini.domain.note.domain.Note;
 import com.example.wini.domain.note.domain.SortOrder;
 import com.example.wini.domain.note.dto.request.NoteCreateRequest;
 import com.example.wini.domain.note.dto.response.NoteResponse;
+import com.example.wini.domain.note.dto.response.SimpleNoteResponse;
 import com.example.wini.domain.note.repository.NoteRepository;
 import com.example.wini.domain.notification.domain.NotificationType;
 import com.example.wini.domain.notification.event.NotificationEvent;
@@ -55,24 +56,24 @@ public class NoteService {
     }
 
     @Transactional(readOnly = true)
-    public List<NoteResponse> findLatestNotes() {
+    public List<SimpleNoteResponse> findLatestNotes() {
         Member me = memberUtil.getCurrentMember();
         Room room = roomRepository
                 .findOpenRoomByMemberId(me.getId())
                 .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
         List<Note> notes = noteRepository.findLatestNotes(me.getId(), room.getId());
-        return notes.stream().map(NoteResponse::from).toList();
+        return notes.stream().map(SimpleNoteResponse::from).toList();
     }
 
     @Transactional(readOnly = true)
-    public List<NoteResponse> findSavedNotesSorted(String sort) {
+    public List<SimpleNoteResponse> findSavedNotesSorted(String sort) {
         Member me = memberUtil.getCurrentMember();
         Room room = roomRepository
                 .findOpenRoomByMemberId(me.getId())
                 .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
         SortOrder sortOrder = SortOrder.from(sort);
         List<Note> notes = noteRepository.findSavedNotesSortedByCreatedAt(me.getId(), room.getId(), sortOrder);
-        return notes.stream().map(NoteResponse::from).toList();
+        return notes.stream().map(SimpleNoteResponse::from).toList();
     }
 
     @Transactional(readOnly = false)

--- a/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     // Note
     NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 마음쪽지입니다."),
     NOTE_RECEIVER_MISMATCH(HttpStatus.BAD_REQUEST, "마음쪽지의 수신자가 아닙니다."),
+    SORT_ORDER_NOT_FOUND(HttpStatus.BAD_REQUEST, "잘못된 정렬 순서입니다."),
 
     // Template
     EMOTION_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "잘못된 감정 분류입니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #55

## 📌 작업 내용 및 특이사항
- 저장된 쪽지 조회시 정렬기준 쿼리 추가
- 쪽지 리스트 조회시 간단한 쪽지 응답 dto 반환하도록 수정
- 최근 받은 쪽지 리스트 조회시 최신순 정렬 로직 추가

## 📝 참고사항
-

## 📚 기타
- 현재는 최신순, 오래된순 정렬밖에 없어 간단한 쿼리로 구현하였으나, 이후 페이징 기능 추가시 Pageable로 수정하면 좋을 것 같습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 쪽지 목록 정렬 지원: 최신 쪽지는 기본 최신순, 보관 쪽지는 요청 파라미터 sort=latest|oldest로 정렬 선택 가능.
  * 목록 응답을 경량화해 로딩 속도와 가독성 개선(항목에 ID, 감정, 읽음 여부, 생성일만 포함).
  * 잘못된 정렬 값 입력 시 명확한 오류 안내로 사용성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->