### PR TITLE
fix: 상태 지속시간 미설정 시 역변환 안되는 오류

### DIFF
--- a/src/main/java/com/example/wini/domain/member/dto/common/ReservedTimeInfo.java
+++ b/src/main/java/com/example/wini/domain/member/dto/common/ReservedTimeInfo.java
@@ -1,9 +1,14 @@
 package com.example.wini.domain.member.dto.common;
 
+import static com.example.wini.global.common.constant.StatusReserveTimeConstants.INDEFINITE_HOUR;
+import static com.example.wini.global.common.constant.StatusReserveTimeConstants.INDEFINITE_MINUTE;
+import static com.example.wini.global.common.constant.StatusReserveTimeConstants.INDEFINITE_SECONDS;
+import static com.example.wini.global.common.constant.StatusReserveTimeConstants.SECONDS_PER_HOUR;
+import static com.example.wini.global.common.constant.StatusReserveTimeConstants.SECONDS_PER_MINUTE;
+
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import java.time.Duration;
 
 public record ReservedTimeInfo(
         @NotNull @Min(value = -1) @Max(value = 12) Long hour, @NotNull @Min(value = -1) @Max(value = 59) Long minute) {
@@ -11,11 +16,10 @@ public record ReservedTimeInfo(
         return new ReservedTimeInfo(hour, minute);
     }
 
-    public Duration toDuration() {
-        if (this.hour == -1 && this.minute == -1) {
-            return Duration.ofDays(365L * 100);
+    public long toSeconds() {
+        if (this.hour == INDEFINITE_HOUR && this.minute == INDEFINITE_MINUTE) {
+            return INDEFINITE_SECONDS;
         }
-
-        return Duration.ofHours(this.hour).plusMinutes(this.minute);
+        return this.hour * SECONDS_PER_HOUR + this.minute * SECONDS_PER_MINUTE;
     }
 }

--- a/src/main/java/com/example/wini/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/wini/domain/member/service/MemberService.java
@@ -1,5 +1,8 @@
 package com.example.wini.domain.member.service;
 
+import static com.example.wini.global.common.constant.StatusReserveTimeConstants.INDEFINITE_HOUR;
+import static com.example.wini.global.common.constant.StatusReserveTimeConstants.INDEFINITE_MINUTE;
+import static com.example.wini.global.common.constant.StatusReserveTimeConstants.INDEFINITE_SECONDS;
 import static com.example.wini.global.error.exception.ErrorCode.MATE_NOT_FOUND;
 import static com.example.wini.global.error.exception.ErrorCode.STATUS_NOT_FOUND;
 
@@ -72,6 +75,10 @@ public class MemberService {
     }
 
     private ReservedTimeInfo createReservedTimeInfo(long durationSeconds) {
+        if (durationSeconds == INDEFINITE_SECONDS) {
+            return ReservedTimeInfo.of(INDEFINITE_HOUR, INDEFINITE_MINUTE);
+        }
+
         Duration duration = Duration.ofSeconds(durationSeconds);
         return ReservedTimeInfo.of(duration.toHours(), duration.toMinutes() % 60);
     }
@@ -83,8 +90,7 @@ public class MemberService {
         Status status =
                 statusRepository.findById(request.statusId()).orElseThrow(() -> new CustomException(STATUS_NOT_FOUND));
 
-        Duration statusDuration = request.reservedTimeInfo().toDuration();
-        Long statusDurationSeconds = statusDuration.getSeconds();
+        Long statusDurationSeconds = request.reservedTimeInfo().toSeconds();
 
         member.updateStatus(status, request.startedAt(), statusDurationSeconds);
         notifyRoommateOfStatusUpdate(member.getId());

--- a/src/main/java/com/example/wini/global/common/constant/StatusReserveTimeConstants.java
+++ b/src/main/java/com/example/wini/global/common/constant/StatusReserveTimeConstants.java
@@ -1,0 +1,13 @@
+package com.example.wini.global.common.constant;
+
+public class StatusReserveTimeConstants {
+
+    public static final int SECONDS_PER_HOUR = 3600;
+    public static final int SECONDS_PER_MINUTE = 60;
+
+    public static final long INDEFINITE_SECONDS = 365L * 100 * 24 * 60 * 60;
+    public static final long INDEFINITE_HOUR = -1L;
+    public static final long INDEFINITE_MINUTE = -1L;
+
+    private StatusReserveTimeConstants() {}
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #92 

## 📌 작업 내용 및 특이사항
- 상태 예약시간 무한값 변환 오류 수정

## 📝 참고사항
- 상태 예약시간이 무기한을 의미하는 값(약 100년 = 3,153,600,000초)일 때 기존 로직에서 시,분 단위로 변환되지 못하는 문제가 발생해 이를 수정하였습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 예약 시간에서 “무기한” 상태를 명확히 지원하여 표시/처리가 일관됩니다.
- 버그 수정
  - 시간 계산 방식 개선으로 간헐적 표시 오차와 해석 문제를 완화했습니다.
- 리팩터링
  - 시간 단위 처리를 초 단위 기반으로 단순화해 안정성과 유지보수성을 높였습니다.
- 잡무(Chores)
  - 시간 관련 상수를 중앙에서 관리하도록 정리해 향후 설정과 확장을 용이하게 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->