### PR TITLE
fix: 나의 성장 조회시 발생하는 오류

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Querydsl
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.10.1'
+    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.10.1:jpa'
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Querydsl
-    implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.10.1'
-    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.10.1:jpa'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
-    // Hibernate 직접 버전 지정
-    implementation 'org.hibernate.orm:hibernate-core:6.2.7.Final'
-
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -52,8 +49,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Querydsl
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.10.1'
+    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.10.1:jpa'
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // Hibernate 직접 버전 지정
+    implementation 'org.hibernate.orm:hibernate-core:6.2.7.Final'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
@@ -2,4 +2,4 @@ package com.example.wini.domain.log.dto.response;
 
 import com.example.wini.domain.template.domain.Action;
 
-public record ActionChange(Action action, int thisMonthCount, int lastMonthCount) {}
+public record ActionChange(Action action, int monthlyChange) {}

--- a/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
@@ -1,18 +1,5 @@
 package com.example.wini.domain.log.dto.response;
 
 import com.example.wini.domain.template.domain.Action;
-import com.querydsl.core.annotations.QueryProjection;
-import lombok.Getter;
 
-@Getter
-public class ActionChange {
-
-    private Action action;
-    private Long change;
-
-    @QueryProjection
-    public ActionChange(Action action, Long change) {
-        this.action = action;
-        this.change = change;
-    }
-}
+public record ActionChange(Action action, Long change) {}

--- a/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
@@ -1,5 +1,18 @@
 package com.example.wini.domain.log.dto.response;
 
 import com.example.wini.domain.template.domain.Action;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
 
-public record ActionChange(Action action, Long change) {}
+@Getter
+public class ActionChange {
+
+    private Action action;
+    private Long change;
+
+    @QueryProjection
+    public ActionChange(Action action, Long change) {
+        this.action = action;
+        this.change = change;
+    }
+}

--- a/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
@@ -2,4 +2,4 @@ package com.example.wini.domain.log.dto.response;
 
 import com.example.wini.domain.template.domain.Action;
 
-public record ActionChange(Action action, long monthlyChange) {}
+public record ActionChange(Action action, Long monthlyChange) {}

--- a/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
@@ -2,4 +2,4 @@ package com.example.wini.domain.log.dto.response;
 
 import com.example.wini.domain.template.domain.Action;
 
-public record ActionChange(Action action, int monthlyChange) {}
+public record ActionChange(Action action, long monthlyChange) {}

--- a/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
@@ -1,6 +1,7 @@
 package com.example.wini.domain.log.dto.response;
 
 import com.example.wini.domain.template.domain.Action;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 
 @Getter
@@ -9,7 +10,7 @@ public class ActionChange {
     private Action action;
     private Long change;
 
-    //    @QueryProjection
+    @QueryProjection
     public ActionChange(Action action, Long change) {
         this.action = action;
         this.change = change;

--- a/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
@@ -2,4 +2,4 @@ package com.example.wini.domain.log.dto.response;
 
 import com.example.wini.domain.template.domain.Action;
 
-public record ActionChange(Action action, Long change) {}
+public record ActionChange(Action action, int thisMonthCount, int lastMonthCount) {}

--- a/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/ActionChange.java
@@ -1,7 +1,6 @@
 package com.example.wini.domain.log.dto.response;
 
 import com.example.wini.domain.template.domain.Action;
-import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 
 @Getter
@@ -10,7 +9,7 @@ public class ActionChange {
     private Action action;
     private Long change;
 
-    @QueryProjection
+    //    @QueryProjection
     public ActionChange(Action action, Long change) {
         this.action = action;
         this.change = change;

--- a/src/main/java/com/example/wini/domain/log/dto/response/SimpleActionChange.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/SimpleActionChange.java
@@ -1,6 +1,6 @@
 package com.example.wini.domain.log.dto.response;
 
-public record SimpleActionChange(String text, int monthlyChange) {
+public record SimpleActionChange(String text, long monthlyChange) {
     public static SimpleActionChange from(ActionChange actionChange) {
         return new SimpleActionChange(actionChange.action().getText(), actionChange.monthlyChange());
     }

--- a/src/main/java/com/example/wini/domain/log/dto/response/SimpleActionChange.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/SimpleActionChange.java
@@ -2,6 +2,9 @@ package com.example.wini.domain.log.dto.response;
 
 public record SimpleActionChange(String text, Long monthlyChange) {
     public static SimpleActionChange from(ActionChange actionChange) {
+        if (actionChange == null) {
+            return new SimpleActionChange(null, null);
+        }
         return new SimpleActionChange(actionChange.action().getText(), actionChange.monthlyChange());
     }
 }

--- a/src/main/java/com/example/wini/domain/log/dto/response/SimpleActionChange.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/SimpleActionChange.java
@@ -2,6 +2,6 @@ package com.example.wini.domain.log.dto.response;
 
 public record SimpleActionChange(String text, long change) {
     public static SimpleActionChange from(ActionChange actionChange) {
-        return new SimpleActionChange(actionChange.action().getText(), actionChange.change());
+        return new SimpleActionChange(actionChange.getAction().getText(), actionChange.getChange());
     }
 }

--- a/src/main/java/com/example/wini/domain/log/dto/response/SimpleActionChange.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/SimpleActionChange.java
@@ -2,6 +2,6 @@ package com.example.wini.domain.log.dto.response;
 
 public record SimpleActionChange(String text, long change) {
     public static SimpleActionChange from(ActionChange actionChange) {
-        return new SimpleActionChange(actionChange.getAction().getText(), actionChange.getChange());
+        return new SimpleActionChange(actionChange.action().getText(), actionChange.change());
     }
 }

--- a/src/main/java/com/example/wini/domain/log/dto/response/SimpleActionChange.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/SimpleActionChange.java
@@ -1,8 +1,7 @@
 package com.example.wini.domain.log.dto.response;
 
-public record SimpleActionChange(String text, int change) {
+public record SimpleActionChange(String text, int monthlyChange) {
     public static SimpleActionChange from(ActionChange actionChange) {
-        return new SimpleActionChange(
-                actionChange.action().getText(), actionChange.thisMonthCount() - actionChange.lastMonthCount());
+        return new SimpleActionChange(actionChange.action().getText(), actionChange.monthlyChange());
     }
 }

--- a/src/main/java/com/example/wini/domain/log/dto/response/SimpleActionChange.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/SimpleActionChange.java
@@ -1,6 +1,6 @@
 package com.example.wini.domain.log.dto.response;
 
-public record SimpleActionChange(String text, long monthlyChange) {
+public record SimpleActionChange(String text, Long monthlyChange) {
     public static SimpleActionChange from(ActionChange actionChange) {
         return new SimpleActionChange(actionChange.action().getText(), actionChange.monthlyChange());
     }

--- a/src/main/java/com/example/wini/domain/log/dto/response/SimpleActionChange.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/SimpleActionChange.java
@@ -1,7 +1,8 @@
 package com.example.wini.domain.log.dto.response;
 
-public record SimpleActionChange(String text, long change) {
+public record SimpleActionChange(String text, int change) {
     public static SimpleActionChange from(ActionChange actionChange) {
-        return new SimpleActionChange(actionChange.action().getText(), actionChange.change());
+        return new SimpleActionChange(
+                actionChange.action().getText(), actionChange.thisMonthCount() - actionChange.lastMonthCount());
     }
 }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -15,6 +15,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.DayOfWeek;
@@ -82,7 +83,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .otherwise(0L);
 
         List<ActionChange> results = queryFactory
-                .select(Projections.constructor(ActionChange.class, action, monthlyChange.sum()))
+                .select(Projections.constructor(
+                        ActionChange.class, action, Expressions.numberTemplate(Long.class, "sum({0})", monthlyChange)))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -108,7 +110,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .otherwise(0L);
 
         List<ActionChange> results = queryFactory
-                .select(Projections.constructor(ActionChange.class, action, monthlyChange.sum()))
+                .select(Projections.constructor(
+                        ActionChange.class, action, Expressions.numberTemplate(Long.class, "sum({0})", monthlyChange)))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -75,8 +75,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         LocalDate today = LocalDate.now();
         NumberExpression<Long> thisMonthNotes = countThisMonthNotes(today);
         NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
-        NumberExpression<Long> increaseCount =
-                thisMonthNotes.subtract(lastMonthNotes).as("increaseCount");
+        NumberExpression<Long> increaseCount = thisMonthNotes.subtract(lastMonthNotes);
 
         return queryFactory
                 .select(new QActionChange(action, increaseCount.longValue()))
@@ -96,8 +95,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         LocalDate today = LocalDate.now();
         NumberExpression<Long> thisMonthNotes = countThisMonthNotes(today);
         NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
-        NumberExpression<Long> decreaseCount =
-                thisMonthNotes.subtract(lastMonthNotes).as("decreaseCount");
+        NumberExpression<Long> decreaseCount = thisMonthNotes.subtract(lastMonthNotes);
 
         return queryFactory
                 .select(new QActionChange(action, decreaseCount.longValue()))

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -5,12 +5,12 @@ import static com.example.wini.domain.template.domain.QAction.action;
 import static com.example.wini.domain.template.domain.QActionCategory.actionCategory;
 
 import com.example.wini.domain.log.dto.response.ActionChange;
-import com.example.wini.domain.log.dto.response.QActionChange;
 import com.example.wini.domain.log.dto.response.WeeklyNoteCount;
 import com.example.wini.domain.note.domain.Note;
 import com.example.wini.domain.note.domain.SortOrder;
 import com.example.wini.domain.template.domain.ActionCategory;
 import com.example.wini.domain.template.domain.EmotionType;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -78,8 +78,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
         NumberExpression<Long> increaseCount = thisMonthNotes.subtract(lastMonthNotes);
 
-        List<ActionChange> results = queryFactory
-                .select(new QActionChange(action, increaseCount.longValue()))
+        List<Tuple> resultsTuple = queryFactory
+                .select(action, increaseCount)
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -89,9 +89,9 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .groupBy(action)
                 .fetch();
 
-        return results.stream()
-                .sorted(Comparator.comparing(ActionChange::getChange).reversed())
-                .findFirst()
+        return resultsTuple.stream()
+                .map(tuple -> new ActionChange(tuple.get(action), tuple.get(increaseCount)))
+                .max(Comparator.comparing(ActionChange::getChange))
                 .orElse(null);
     }
 
@@ -102,8 +102,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
         NumberExpression<Long> decreaseCount = thisMonthNotes.subtract(lastMonthNotes);
 
-        List<ActionChange> results = queryFactory
-                .select(new QActionChange(action, decreaseCount.longValue()))
+        List<Tuple> resultsTuple = queryFactory
+                .select(action, decreaseCount)
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -113,9 +113,9 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .groupBy(action)
                 .fetch();
 
-        return results.stream()
-                .sorted(Comparator.comparing(ActionChange::getChange))
-                .findFirst()
+        return resultsTuple.stream()
+                .map(tuple -> new ActionChange(tuple.get(action), tuple.get(decreaseCount)))
+                .min(Comparator.comparing(ActionChange::getChange))
                 .orElse(null);
     }
 

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -15,6 +15,7 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.DayOfWeek;
@@ -204,9 +205,13 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         LocalDateTime endOfLastMonth = firstDayOfThisMonth.atStartOfDay();
 
         return new CaseBuilder()
-                .when(note.createdAt.goe(startOfThisMonth).and(note.createdAt.lt(endOfThisMonth)))
+                .when(note.createdAt
+                        .goe(Expressions.asDateTime(startOfThisMonth))
+                        .and(note.createdAt.lt(Expressions.asDateTime(endOfThisMonth))))
                 .then(1L)
-                .when(note.createdAt.goe(startOfLastMonth).and(note.createdAt.lt(endOfLastMonth)))
+                .when(note.createdAt
+                        .goe(Expressions.asDateTime(startOfLastMonth))
+                        .and(note.createdAt.lt(Expressions.asDateTime(endOfLastMonth))))
                 .then(-1L)
                 .otherwise(0L)
                 .sum();

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -81,11 +81,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                         new CaseBuilder()
                                 .when(isCreatedThisMonth(today))
                                 .then(1)
-                                .otherwise(0)
-                                .sum(),
-                        new CaseBuilder()
                                 .when(isCreatedLastMonth(today))
-                                .then(1)
+                                .then(-1)
                                 .otherwise(0)
                                 .sum()))
                 .from(note)
@@ -98,7 +95,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .fetch();
 
         return results.stream()
-                .max(Comparator.comparing(ac -> ac.thisMonthCount() - ac.lastMonthCount()))
+                .max(Comparator.comparing(ActionChange::monthlyChange))
                 .orElse(null);
     }
 
@@ -113,11 +110,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                         new CaseBuilder()
                                 .when(isCreatedThisMonth(today))
                                 .then(1)
-                                .otherwise(0)
-                                .sum(),
-                        new CaseBuilder()
                                 .when(isCreatedLastMonth(today))
-                                .then(1)
+                                .then(-1)
                                 .otherwise(0)
                                 .sum()))
                 .from(note)
@@ -130,7 +124,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .fetch();
 
         return results.stream()
-                .min(Comparator.comparing(ac -> ac.thisMonthCount() - ac.lastMonthCount()))
+                .min(Comparator.comparing(ActionChange::monthlyChange))
                 .orElse(null);
     }
 
@@ -232,25 +226,6 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
 
         return note.createdAt.goe(startOfLastMonth).and(note.createdAt.lt(endOfLastMonth));
     }
-
-    //    private NumberExpression<Long> calculateMonthlyChange(LocalDate today) {
-    //        LocalDate firstDayOfThisMonth = today.withDayOfMonth(1);
-    //        LocalDate firstDayOfLastMonth = firstDayOfThisMonth.minusMonths(1);
-    //
-    //        LocalDateTime startOfThisMonth = firstDayOfThisMonth.atStartOfDay();
-    //        LocalDateTime endOfThisMonth = firstDayOfThisMonth.plusMonths(1).atStartOfDay();
-    //
-    //        LocalDateTime startOfLastMonth = firstDayOfLastMonth.atStartOfDay();
-    //        LocalDateTime endOfLastMonth = firstDayOfThisMonth.atStartOfDay();
-    //
-    //        return new CaseBuilder()
-    //                .when(note.createdAt.goe(startOfThisMonth).and(note.createdAt.lt(endOfThisMonth)))
-    //                .then(1L)
-    //                .when(note.createdAt.goe(startOfLastMonth).and(note.createdAt.lt(endOfLastMonth)))
-    //                .then(-1L)
-    //                .otherwise(0L)
-    //                .sum();
-    //    }
 
     private BooleanExpression isCreatedLatest() {
         return note.createdAt.after(LocalDateTime.now().minusHours(24));

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -15,7 +15,6 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.DayOfWeek;
@@ -75,32 +74,17 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     @Override
     public ActionChange findMostIncreasedPositiveActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
-        LocalDate firstDayOfThisMonth = today.withDayOfMonth(1);
-        LocalDate firstDayOfLastMonth = firstDayOfThisMonth.minusMonths(1);
-
-        // 모든 계산 로직을 쿼리 내부에 직접 작성
-        NumberExpression<Long> increaseCount = new CaseBuilder()
-                .when(note.createdAt
-                        .goe(Expressions.asDateTime(firstDayOfThisMonth.atStartOfDay()))
-                        .and(note.createdAt.lt(Expressions.asDateTime(
-                                firstDayOfThisMonth.plusMonths(1).atStartOfDay()))))
-                .then(1L)
-                .when(note.createdAt
-                        .goe(Expressions.asDateTime(firstDayOfLastMonth.atStartOfDay()))
-                        .and(note.createdAt.lt(Expressions.asDateTime(firstDayOfThisMonth.atStartOfDay()))))
-                .then(-1L)
-                .otherwise(0L)
-                .sum();
+        NumberExpression<Long> increaseCount = calculateMonthlyChange(today);
 
         List<ActionChange> results = queryFactory
-                .select(Projections.constructor(ActionChange.class, action, increaseCount.as("change")))
+                .select(Projections.constructor(ActionChange.class, action, increaseCount))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
                 .where(isThisRoom(roomId)
                         .and(isReceiver(memberId))
                         .and(actionCategory.emotionType.eq(EmotionType.POSITIVE)))
-                .groupBy(action)
+                .groupBy(action.id)
                 .fetch();
 
         return results.stream().max(Comparator.comparing(ActionChange::change)).orElse(null);
@@ -109,32 +93,17 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     @Override
     public ActionChange findMostDecreasedNegativeActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
-        LocalDate firstDayOfThisMonth = today.withDayOfMonth(1);
-        LocalDate firstDayOfLastMonth = firstDayOfThisMonth.minusMonths(1);
-
-        // 모든 계산 로직을 쿼리 내부에 직접 작성
-        NumberExpression<Long> decreaseCount = new CaseBuilder()
-                .when(note.createdAt
-                        .goe(Expressions.asDateTime(firstDayOfThisMonth.atStartOfDay()))
-                        .and(note.createdAt.lt(Expressions.asDateTime(
-                                firstDayOfThisMonth.plusMonths(1).atStartOfDay()))))
-                .then(1L)
-                .when(note.createdAt
-                        .goe(Expressions.asDateTime(firstDayOfLastMonth.atStartOfDay()))
-                        .and(note.createdAt.lt(Expressions.asDateTime(firstDayOfThisMonth.atStartOfDay()))))
-                .then(-1L)
-                .otherwise(0L)
-                .sum();
+        NumberExpression<Long> decreaseCount = calculateMonthlyChange(today);
 
         List<ActionChange> results = queryFactory
-                .select(Projections.constructor(ActionChange.class, action, decreaseCount.as("change")))
+                .select(Projections.constructor(ActionChange.class, action, decreaseCount))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
                 .where(isThisRoom(roomId)
                         .and(isReceiver(memberId))
                         .and(actionCategory.emotionType.eq(EmotionType.NEGATIVE)))
-                .groupBy(action)
+                .groupBy(action.id)
                 .fetch();
 
         return results.stream().min(Comparator.comparing(ActionChange::change)).orElse(null);
@@ -231,13 +200,9 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         LocalDateTime endOfLastMonth = firstDayOfThisMonth.atStartOfDay();
 
         return new CaseBuilder()
-                .when(note.createdAt
-                        .goe(Expressions.asDateTime(startOfThisMonth))
-                        .and(note.createdAt.lt(Expressions.asDateTime(endOfThisMonth))))
+                .when(note.createdAt.goe(startOfThisMonth).and(note.createdAt.lt(endOfThisMonth)))
                 .then(1L)
-                .when(note.createdAt
-                        .goe(Expressions.asDateTime(startOfLastMonth))
-                        .and(note.createdAt.lt(Expressions.asDateTime(endOfLastMonth))))
+                .when(note.createdAt.goe(startOfLastMonth).and(note.createdAt.lt(endOfLastMonth)))
                 .then(-1L)
                 .otherwise(0L)
                 .sum();

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -80,8 +80,10 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .then(-1L)
                 .otherwise(0L);
 
+        NumberExpression<Long> monthlyChangeSum = monthlyChange.sum().coalesce(0L);
+
         List<Tuple> results = queryFactory
-                .select(action, monthlyChange.sum())
+                .select(action, monthlyChangeSum)
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -92,7 +94,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .fetch();
 
         return results.stream()
-                .map(t -> new ActionChange(t.get(action), t.get(monthlyChange.sum())))
+                .map(t -> new ActionChange(t.get(action), t.get(monthlyChangeSum)))
                 .max(Comparator.comparing(ActionChange::monthlyChange))
                 .orElse(null);
     }
@@ -108,8 +110,10 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .then(-1L)
                 .otherwise(0L);
 
+        NumberExpression<Long> monthlyChangeSum = monthlyChange.sum().coalesce(0L);
+
         List<Tuple> results = queryFactory
-                .select(action, monthlyChange.sum())
+                .select(action, monthlyChangeSum)
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -120,7 +124,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .fetch();
 
         return results.stream()
-                .map(t -> new ActionChange(t.get(action), t.get(monthlyChange.sum())))
+                .map(t -> new ActionChange(t.get(action), t.get(monthlyChangeSum)))
                 .min(Comparator.comparing(ActionChange::monthlyChange))
                 .orElse(null);
     }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -15,7 +15,6 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -74,10 +73,21 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     @Override
     public ActionChange findMostIncreasedPositiveActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
-        NumberExpression<Long> increaseCount = calculateMonthlyChange(today);
 
         List<ActionChange> results = queryFactory
-                .select(Projections.constructor(ActionChange.class, action, increaseCount))
+                .select(Projections.constructor(
+                        ActionChange.class,
+                        action,
+                        new CaseBuilder()
+                                .when(isCreatedThisMonth(today))
+                                .then(1)
+                                .otherwise(0)
+                                .sum(),
+                        new CaseBuilder()
+                                .when(isCreatedLastMonth(today))
+                                .then(1)
+                                .otherwise(0)
+                                .sum()))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -87,16 +97,29 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .groupBy(action.id)
                 .fetch();
 
-        return results.stream().max(Comparator.comparing(ActionChange::change)).orElse(null);
+        return results.stream()
+                .max(Comparator.comparing(ac -> ac.thisMonthCount() - ac.lastMonthCount()))
+                .orElse(null);
     }
 
     @Override
     public ActionChange findMostDecreasedNegativeActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
-        NumberExpression<Long> decreaseCount = calculateMonthlyChange(today);
 
         List<ActionChange> results = queryFactory
-                .select(Projections.constructor(ActionChange.class, action, decreaseCount))
+                .select(Projections.constructor(
+                        ActionChange.class,
+                        action,
+                        new CaseBuilder()
+                                .when(isCreatedThisMonth(today))
+                                .then(1)
+                                .otherwise(0)
+                                .sum(),
+                        new CaseBuilder()
+                                .when(isCreatedLastMonth(today))
+                                .then(1)
+                                .otherwise(0)
+                                .sum()))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -106,7 +129,9 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .groupBy(action.id)
                 .fetch();
 
-        return results.stream().min(Comparator.comparing(ActionChange::change)).orElse(null);
+        return results.stream()
+                .min(Comparator.comparing(ac -> ac.thisMonthCount() - ac.lastMonthCount()))
+                .orElse(null);
     }
 
     @Override
@@ -189,24 +214,43 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .fetchFirst();
     }
 
-    private NumberExpression<Long> calculateMonthlyChange(LocalDate today) {
+    private BooleanExpression isCreatedThisMonth(LocalDate today) {
         LocalDate firstDayOfThisMonth = today.withDayOfMonth(1);
-        LocalDate firstDayOfLastMonth = firstDayOfThisMonth.minusMonths(1);
 
         LocalDateTime startOfThisMonth = firstDayOfThisMonth.atStartOfDay();
         LocalDateTime endOfThisMonth = firstDayOfThisMonth.plusMonths(1).atStartOfDay();
 
+        return note.createdAt.goe(startOfThisMonth).and(note.createdAt.lt(endOfThisMonth));
+    }
+
+    private BooleanExpression isCreatedLastMonth(LocalDate today) {
+        LocalDate firstDayOfThisMonth = today.withDayOfMonth(1);
+        LocalDate firstDayOfLastMonth = firstDayOfThisMonth.minusMonths(1);
+
         LocalDateTime startOfLastMonth = firstDayOfLastMonth.atStartOfDay();
         LocalDateTime endOfLastMonth = firstDayOfThisMonth.atStartOfDay();
 
-        return new CaseBuilder()
-                .when(note.createdAt.goe(startOfThisMonth).and(note.createdAt.lt(endOfThisMonth)))
-                .then(1L)
-                .when(note.createdAt.goe(startOfLastMonth).and(note.createdAt.lt(endOfLastMonth)))
-                .then(-1L)
-                .otherwise(0L)
-                .sum();
+        return note.createdAt.goe(startOfLastMonth).and(note.createdAt.lt(endOfLastMonth));
     }
+
+    //    private NumberExpression<Long> calculateMonthlyChange(LocalDate today) {
+    //        LocalDate firstDayOfThisMonth = today.withDayOfMonth(1);
+    //        LocalDate firstDayOfLastMonth = firstDayOfThisMonth.minusMonths(1);
+    //
+    //        LocalDateTime startOfThisMonth = firstDayOfThisMonth.atStartOfDay();
+    //        LocalDateTime endOfThisMonth = firstDayOfThisMonth.plusMonths(1).atStartOfDay();
+    //
+    //        LocalDateTime startOfLastMonth = firstDayOfLastMonth.atStartOfDay();
+    //        LocalDateTime endOfLastMonth = firstDayOfThisMonth.atStartOfDay();
+    //
+    //        return new CaseBuilder()
+    //                .when(note.createdAt.goe(startOfThisMonth).and(note.createdAt.lt(endOfThisMonth)))
+    //                .then(1L)
+    //                .when(note.createdAt.goe(startOfLastMonth).and(note.createdAt.lt(endOfLastMonth)))
+    //                .then(-1L)
+    //                .otherwise(0L)
+    //                .sum();
+    //    }
 
     private BooleanExpression isCreatedLatest() {
         return note.createdAt.after(LocalDateTime.now().minusHours(24));

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -78,7 +78,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         NumberExpression<Long> increaseCount = thisMonthNotes.subtract(lastMonthNotes);
 
         return queryFactory
-                .select(new QActionChange(action, increaseCount))
+                .select(new QActionChange(action, increaseCount.longValue()))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -98,7 +98,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         NumberExpression<Long> decreaseCount = thisMonthNotes.subtract(lastMonthNotes);
 
         return queryFactory
-                .select(new QActionChange(action, decreaseCount))
+                .select(new QActionChange(action, decreaseCount.longValue()))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -73,14 +73,15 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     public ActionChange findMostIncreasedPositiveActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
 
-        NumberExpression<Long> monthlyChange = new CaseBuilder()
+        NumberExpression<Integer> rawChange = new CaseBuilder()
                 .when(isCreatedThisMonth(today))
-                .then(1L)
+                .then(1)
                 .when(isCreatedLastMonth(today))
-                .then(-1L)
-                .otherwise(0L);
+                .then(-1)
+                .otherwise(0);
 
-        NumberExpression<Long> monthlyChangeSum = monthlyChange.sum().coalesce(0L);
+        NumberExpression<Long> monthlyChange = rawChange.castToNum(Long.class);
+        NumberExpression<Long> monthlyChangeSum = monthlyChange.sumLong().coalesce(0L);
 
         List<Tuple> results = queryFactory
                 .select(action, monthlyChangeSum)
@@ -103,14 +104,15 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     public ActionChange findMostDecreasedNegativeActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
 
-        NumberExpression<Long> monthlyChange = new CaseBuilder()
+        NumberExpression<Integer> rawChange = new CaseBuilder()
                 .when(isCreatedThisMonth(today))
-                .then(1L)
+                .then(1)
                 .when(isCreatedLastMonth(today))
-                .then(-1L)
-                .otherwise(0L);
+                .then(-1)
+                .otherwise(0);
 
-        NumberExpression<Long> monthlyChangeSum = monthlyChange.sum().coalesce(0L);
+        NumberExpression<Long> monthlyChange = rawChange.castToNum(Long.class);
+        NumberExpression<Long> monthlyChangeSum = monthlyChange.sumLong().coalesce(0L);
 
         List<Tuple> results = queryFactory
                 .select(action, monthlyChangeSum)

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -10,12 +10,11 @@ import com.example.wini.domain.note.domain.Note;
 import com.example.wini.domain.note.domain.SortOrder;
 import com.example.wini.domain.template.domain.ActionCategory;
 import com.example.wini.domain.template.domain.EmotionType;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.DayOfWeek;
@@ -75,6 +74,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     @Override
     public ActionChange findMostIncreasedPositiveActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
+
         NumberExpression<Long> monthlyChange = new CaseBuilder()
                 .when(isCreatedThisMonth(today))
                 .then(1L)
@@ -82,9 +82,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .then(-1L)
                 .otherwise(0L);
 
-        List<ActionChange> results = queryFactory
-                .select(Projections.constructor(
-                        ActionChange.class, action, Expressions.numberTemplate(Long.class, "sum({0})", monthlyChange)))
+        List<Tuple> results = queryFactory
+                .select(action, monthlyChange.sum())
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -95,6 +94,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .fetch();
 
         return results.stream()
+                .map(t -> new ActionChange(t.get(action), t.get(monthlyChange.sum())))
                 .max(Comparator.comparing(ActionChange::monthlyChange))
                 .orElse(null);
     }
@@ -102,6 +102,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     @Override
     public ActionChange findMostDecreasedNegativeActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
+
         NumberExpression<Long> monthlyChange = new CaseBuilder()
                 .when(isCreatedThisMonth(today))
                 .then(1L)
@@ -109,9 +110,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .then(-1L)
                 .otherwise(0L);
 
-        List<ActionChange> results = queryFactory
-                .select(Projections.constructor(
-                        ActionChange.class, action, Expressions.numberTemplate(Long.class, "sum({0})", monthlyChange)))
+        List<Tuple> results = queryFactory
+                .select(action, monthlyChange.sum())
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -122,6 +122,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .fetch();
 
         return results.stream()
+                .map(t -> new ActionChange(t.get(action), t.get(monthlyChange.sum())))
                 .min(Comparator.comparing(ActionChange::monthlyChange))
                 .orElse(null);
     }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -82,8 +82,10 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .then(-1L)
                 .otherwise(0L);
 
+        NumberExpression<Long> monthlyChangeSum = monthlyChange.sum().coalesce(0L);
+
         List<Tuple> results = queryFactory
-                .select(action, monthlyChange.sum())
+                .select(action, monthlyChangeSum)
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -94,7 +96,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .fetch();
 
         return results.stream()
-                .map(t -> new ActionChange(t.get(action), t.get(monthlyChange.sum())))
+                .map(t -> new ActionChange(t.get(action), t.get(monthlyChangeSum)))
                 .max(Comparator.comparing(ActionChange::monthlyChange))
                 .orElse(null);
     }
@@ -110,8 +112,10 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .then(-1L)
                 .otherwise(0L);
 
+        NumberExpression<Long> monthlyChangeSum = monthlyChange.sum().coalesce(0L);
+
         List<Tuple> results = queryFactory
-                .select(action, monthlyChange.sum())
+                .select(action, monthlyChangeSum)
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -122,7 +126,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .fetch();
 
         return results.stream()
-                .map(t -> new ActionChange(t.get(action), t.get(monthlyChange.sum())))
+                .map(t -> new ActionChange(t.get(action), t.get(monthlyChangeSum)))
                 .min(Comparator.comparing(ActionChange::monthlyChange))
                 .orElse(null);
     }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -74,9 +74,10 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     @Override
     public ActionChange findMostIncreasedPositiveActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
-        NumberExpression<Long> thisMonthNotes = countThisMonthNotes(today);
-        NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
-        NumberExpression<Long> increaseCount = thisMonthNotes.subtract(lastMonthNotes);
+        //        NumberExpression<Long> thisMonthNotes = countThisMonthNotes(today);
+        //        NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
+        //        NumberExpression<Long> increaseCount = thisMonthNotes.subtract(lastMonthNotes);
+        NumberExpression<Long> increaseCount = calculateMonthlyChange(today);
 
         List<Tuple> resultsTuple = queryFactory
                 .select(action, increaseCount)
@@ -98,9 +99,10 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     @Override
     public ActionChange findMostDecreasedNegativeActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
-        NumberExpression<Long> thisMonthNotes = countThisMonthNotes(today);
-        NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
-        NumberExpression<Long> decreaseCount = thisMonthNotes.subtract(lastMonthNotes);
+        //        NumberExpression<Long> thisMonthNotes = countThisMonthNotes(today);
+        //        NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
+        //        NumberExpression<Long> decreaseCount = thisMonthNotes.subtract(lastMonthNotes);
+        NumberExpression<Long> decreaseCount = calculateMonthlyChange(today);
 
         List<Tuple> resultsTuple = queryFactory
                 .select(action, decreaseCount)
@@ -223,6 +225,27 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         return new CaseBuilder()
                 .when(note.createdAt.goe(startOfLastMonth).and(note.createdAt.lt(endOfLastMonth)))
                 .then(1L)
+                .otherwise(0L)
+                .sum();
+    }
+
+    private NumberExpression<Long> calculateMonthlyChange(LocalDate today) {
+        LocalDateTime startOfThisMonth = today.withDayOfMonth(1).atStartOfDay();
+        LocalDateTime endOfThisMonth = today.plusDays(1).atStartOfDay();
+
+        LocalDate lastMonthOfToday = today.minusMonths(1);
+        LocalDateTime startOfLastMonth = lastMonthOfToday.withDayOfMonth(1).atStartOfDay();
+        LocalDateTime endOfLastMonth = lastMonthOfToday.plusDays(1).atStartOfDay();
+        if (today.getDayOfMonth() == today.lengthOfMonth()) {
+            endOfLastMonth =
+                    lastMonthOfToday.with(TemporalAdjusters.lastDayOfMonth()).atStartOfDay();
+        }
+
+        return new CaseBuilder()
+                .when(note.createdAt.goe(startOfThisMonth).and(note.createdAt.lt(endOfThisMonth)))
+                .then(1L)
+                .when(note.createdAt.goe(startOfLastMonth).and(note.createdAt.lt(endOfLastMonth)))
+                .then(-1L)
                 .otherwise(0L)
                 .sum();
     }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -82,7 +82,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .then(-1L)
                 .otherwise(0L);
 
-        NumberExpression<Long> monthlyChangeSum = monthlyChange.sum().coalesce(0L);
+        NumberExpression<Long> monthlyChangeSum =
+                monthlyChange.sum().coalesce(0L).longValue();
 
         List<Tuple> results = queryFactory
                 .select(action, monthlyChangeSum)
@@ -112,7 +113,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .then(-1L)
                 .otherwise(0L);
 
-        NumberExpression<Long> monthlyChangeSum = monthlyChange.sum().coalesce(0L);
+        NumberExpression<Long> monthlyChangeSum =
+                monthlyChange.sum().coalesce(0L).longValue();
 
         List<Tuple> results = queryFactory
                 .select(action, monthlyChangeSum)

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -75,7 +75,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         LocalDate today = LocalDate.now();
         NumberExpression<Long> thisMonthNotes = countThisMonthNotes(today);
         NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
-        NumberExpression<Long> increaseCount = thisMonthNotes.subtract(lastMonthNotes);
+        NumberExpression<Long> increaseCount =
+                thisMonthNotes.subtract(lastMonthNotes).as("increaseCount");
 
         return queryFactory
                 .select(new QActionChange(action, increaseCount.longValue()))
@@ -95,7 +96,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         LocalDate today = LocalDate.now();
         NumberExpression<Long> thisMonthNotes = countThisMonthNotes(today);
         NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
-        NumberExpression<Long> decreaseCount = thisMonthNotes.subtract(lastMonthNotes);
+        NumberExpression<Long> decreaseCount =
+                thisMonthNotes.subtract(lastMonthNotes).as("decreaseCount");
 
         return queryFactory
                 .select(new QActionChange(action, decreaseCount.longValue()))

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -75,7 +75,22 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     @Override
     public ActionChange findMostIncreasedPositiveActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
-        NumberExpression<Long> increaseCount = calculateMonthlyChange(today);
+        LocalDate firstDayOfThisMonth = today.withDayOfMonth(1);
+        LocalDate firstDayOfLastMonth = firstDayOfThisMonth.minusMonths(1);
+
+        // 모든 계산 로직을 쿼리 내부에 직접 작성
+        NumberExpression<Long> increaseCount = new CaseBuilder()
+                .when(note.createdAt
+                        .goe(Expressions.asDateTime(firstDayOfThisMonth.atStartOfDay()))
+                        .and(note.createdAt.lt(Expressions.asDateTime(
+                                firstDayOfThisMonth.plusMonths(1).atStartOfDay()))))
+                .then(1L)
+                .when(note.createdAt
+                        .goe(Expressions.asDateTime(firstDayOfLastMonth.atStartOfDay()))
+                        .and(note.createdAt.lt(Expressions.asDateTime(firstDayOfThisMonth.atStartOfDay()))))
+                .then(-1L)
+                .otherwise(0L)
+                .sum();
 
         List<ActionChange> results = queryFactory
                 .select(new QActionChange(action, increaseCount))
@@ -96,7 +111,22 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     @Override
     public ActionChange findMostDecreasedNegativeActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
-        NumberExpression<Long> decreaseCount = calculateMonthlyChange(today);
+        LocalDate firstDayOfThisMonth = today.withDayOfMonth(1);
+        LocalDate firstDayOfLastMonth = firstDayOfThisMonth.minusMonths(1);
+
+        // 모든 계산 로직을 쿼리 내부에 직접 작성
+        NumberExpression<Long> decreaseCount = new CaseBuilder()
+                .when(note.createdAt
+                        .goe(Expressions.asDateTime(firstDayOfThisMonth.atStartOfDay()))
+                        .and(note.createdAt.lt(Expressions.asDateTime(
+                                firstDayOfThisMonth.plusMonths(1).atStartOfDay()))))
+                .then(1L)
+                .when(note.createdAt
+                        .goe(Expressions.asDateTime(firstDayOfLastMonth.atStartOfDay()))
+                        .and(note.createdAt.lt(Expressions.asDateTime(firstDayOfThisMonth.atStartOfDay()))))
+                .then(-1L)
+                .otherwise(0L)
+                .sum();
 
         List<ActionChange> results = queryFactory
                 .select(new QActionChange(action, decreaseCount))
@@ -105,7 +135,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .join(action.actionCategory, actionCategory)
                 .where(isThisRoom(roomId)
                         .and(isReceiver(memberId))
-                        .and(actionCategory.emotionType.eq(EmotionType.NEGATIVE)))
+                        .and(actionCategory.emotionType.eq(EmotionType.NEGATIVE))) // emotionType을 NEGATIVE로 변경
                 .groupBy(action)
                 .fetch();
 

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -230,16 +230,14 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     }
 
     private NumberExpression<Long> calculateMonthlyChange(LocalDate today) {
-        LocalDateTime startOfThisMonth = today.withDayOfMonth(1).atStartOfDay();
-        LocalDateTime endOfThisMonth = today.plusDays(1).atStartOfDay();
+        LocalDate firstDayOfThisMonth = today.withDayOfMonth(1);
+        LocalDate firstDayOfLastMonth = firstDayOfThisMonth.minusMonths(1);
 
-        LocalDate lastMonthOfToday = today.minusMonths(1);
-        LocalDateTime startOfLastMonth = lastMonthOfToday.withDayOfMonth(1).atStartOfDay();
-        LocalDateTime endOfLastMonth = lastMonthOfToday.plusDays(1).atStartOfDay();
-        if (today.getDayOfMonth() == today.lengthOfMonth()) {
-            endOfLastMonth =
-                    lastMonthOfToday.with(TemporalAdjusters.lastDayOfMonth()).atStartOfDay();
-        }
+        LocalDateTime startOfThisMonth = firstDayOfThisMonth.atStartOfDay();
+        LocalDateTime endOfThisMonth = firstDayOfThisMonth.plusMonths(1).atStartOfDay();
+
+        LocalDateTime startOfLastMonth = firstDayOfLastMonth.atStartOfDay();
+        LocalDateTime endOfLastMonth = firstDayOfThisMonth.atStartOfDay();
 
         return new CaseBuilder()
                 .when(note.createdAt.goe(startOfThisMonth).and(note.createdAt.lt(endOfThisMonth)))

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -15,6 +15,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -73,18 +74,15 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     @Override
     public ActionChange findMostIncreasedPositiveActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
+        NumberExpression<Integer> monthlyChange = new CaseBuilder()
+                .when(isCreatedThisMonth(today))
+                .then(1)
+                .when(isCreatedLastMonth(today))
+                .then(-1)
+                .otherwise(0);
 
         List<ActionChange> results = queryFactory
-                .select(Projections.constructor(
-                        ActionChange.class,
-                        action,
-                        new CaseBuilder()
-                                .when(isCreatedThisMonth(today))
-                                .then(1)
-                                .when(isCreatedLastMonth(today))
-                                .then(-1)
-                                .otherwise(0)
-                                .sum()))
+                .select(Projections.constructor(ActionChange.class, action, monthlyChange.sum()))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -102,18 +100,15 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     @Override
     public ActionChange findMostDecreasedNegativeActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
+        NumberExpression<Integer> monthlyChange = new CaseBuilder()
+                .when(isCreatedThisMonth(today))
+                .then(1)
+                .when(isCreatedLastMonth(today))
+                .then(-1)
+                .otherwise(0);
 
         List<ActionChange> results = queryFactory
-                .select(Projections.constructor(
-                        ActionChange.class,
-                        action,
-                        new CaseBuilder()
-                                .when(isCreatedThisMonth(today))
-                                .then(1)
-                                .when(isCreatedLastMonth(today))
-                                .then(-1)
-                                .otherwise(0)
-                                .sum()))
+                .select(Projections.constructor(ActionChange.class, action, monthlyChange.sum()))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -5,12 +5,12 @@ import static com.example.wini.domain.template.domain.QAction.action;
 import static com.example.wini.domain.template.domain.QActionCategory.actionCategory;
 
 import com.example.wini.domain.log.dto.response.ActionChange;
+import com.example.wini.domain.log.dto.response.QActionChange;
 import com.example.wini.domain.log.dto.response.WeeklyNoteCount;
 import com.example.wini.domain.note.domain.Note;
 import com.example.wini.domain.note.domain.SortOrder;
 import com.example.wini.domain.template.domain.ActionCategory;
 import com.example.wini.domain.template.domain.EmotionType;
-import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -74,13 +74,10 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     @Override
     public ActionChange findMostIncreasedPositiveActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
-        //        NumberExpression<Long> thisMonthNotes = countThisMonthNotes(today);
-        //        NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
-        //        NumberExpression<Long> increaseCount = thisMonthNotes.subtract(lastMonthNotes);
         NumberExpression<Long> increaseCount = calculateMonthlyChange(today);
 
-        List<Tuple> resultsTuple = queryFactory
-                .select(action, increaseCount)
+        List<ActionChange> results = queryFactory
+                .select(new QActionChange(action, increaseCount))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -90,8 +87,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .groupBy(action)
                 .fetch();
 
-        return resultsTuple.stream()
-                .map(tuple -> new ActionChange(tuple.get(action), tuple.get(increaseCount)))
+        return results.stream()
                 .max(Comparator.comparing(ActionChange::getChange))
                 .orElse(null);
     }
@@ -99,13 +95,10 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     @Override
     public ActionChange findMostDecreasedNegativeActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
-        //        NumberExpression<Long> thisMonthNotes = countThisMonthNotes(today);
-        //        NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
-        //        NumberExpression<Long> decreaseCount = thisMonthNotes.subtract(lastMonthNotes);
         NumberExpression<Long> decreaseCount = calculateMonthlyChange(today);
 
-        List<Tuple> resultsTuple = queryFactory
-                .select(action, decreaseCount)
+        List<ActionChange> results = queryFactory
+                .select(new QActionChange(action, decreaseCount))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -115,8 +108,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .groupBy(action)
                 .fetch();
 
-        return resultsTuple.stream()
-                .map(tuple -> new ActionChange(tuple.get(action), tuple.get(decreaseCount)))
+        return results.stream()
                 .min(Comparator.comparing(ActionChange::getChange))
                 .orElse(null);
     }
@@ -200,34 +192,6 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .where(isThisRoom(roomId))
                 .fetchFirst();
     }
-
-    //    private NumberExpression<Long> countThisMonthNotes(LocalDate today) {
-    //        LocalDateTime startOfThisMonth = today.withDayOfMonth(1).atStartOfDay();
-    //        LocalDateTime endOfThisMonth = today.plusDays(1).atStartOfDay();
-    //
-    //        return new CaseBuilder()
-    //                .when(note.createdAt.goe(startOfThisMonth).and(note.createdAt.lt(endOfThisMonth)))
-    //                .then(1L)
-    //                .otherwise(0L)
-    //                .sum();
-    //    }
-
-    //    private NumberExpression<Long> countLastMonthNotes(LocalDate today) {
-    //        LocalDate lastMonthOfToday = today.minusMonths(1);
-    //
-    //        LocalDateTime startOfLastMonth = lastMonthOfToday.withDayOfMonth(1).atStartOfDay();
-    //        LocalDateTime endOfLastMonth = lastMonthOfToday.plusDays(1).atStartOfDay();
-    //        if (today.getDayOfMonth() == today.lengthOfMonth()) {
-    //            endOfLastMonth =
-    //                    lastMonthOfToday.with(TemporalAdjusters.lastDayOfMonth()).atStartOfDay();
-    //        }
-    //
-    //        return new CaseBuilder()
-    //                .when(note.createdAt.goe(startOfLastMonth).and(note.createdAt.lt(endOfLastMonth)))
-    //                .then(1L)
-    //                .otherwise(0L)
-    //                .sum();
-    //    }
 
     private NumberExpression<Long> calculateMonthlyChange(LocalDate today) {
         LocalDate firstDayOfThisMonth = today.withDayOfMonth(1);

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -74,12 +74,12 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     @Override
     public ActionChange findMostIncreasedPositiveActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
-        NumberExpression<Integer> monthlyChange = new CaseBuilder()
+        NumberExpression<Long> monthlyChange = new CaseBuilder()
                 .when(isCreatedThisMonth(today))
-                .then(1)
+                .then(1L)
                 .when(isCreatedLastMonth(today))
-                .then(-1)
-                .otherwise(0);
+                .then(-1L)
+                .otherwise(0L);
 
         List<ActionChange> results = queryFactory
                 .select(Projections.constructor(ActionChange.class, action, monthlyChange.sum()))
@@ -100,12 +100,12 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
     @Override
     public ActionChange findMostDecreasedNegativeActionChange(Long memberId, Long roomId) {
         LocalDate today = LocalDate.now();
-        NumberExpression<Integer> monthlyChange = new CaseBuilder()
+        NumberExpression<Long> monthlyChange = new CaseBuilder()
                 .when(isCreatedThisMonth(today))
-                .then(1)
+                .then(1L)
                 .when(isCreatedLastMonth(today))
-                .then(-1)
-                .otherwise(0);
+                .then(-1L)
+                .otherwise(0L);
 
         List<ActionChange> results = queryFactory
                 .select(Projections.constructor(ActionChange.class, action, monthlyChange.sum()))

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -13,9 +13,7 @@ import com.example.wini.domain.template.domain.EmotionType;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -82,8 +80,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .then(-1L)
                 .otherwise(0L);
 
-        NumberExpression<Long> monthlyChangeSum =
-                monthlyChange.sum().coalesce(0L).longValue();
+        NumberExpression<Long> monthlyChangeSum = Expressions.numberTemplate(Long.class, "sum({0})", monthlyChange)
+                .coalesce(0L);
 
         List<Tuple> results = queryFactory
                 .select(action, monthlyChangeSum)
@@ -113,8 +111,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .then(-1L)
                 .otherwise(0L);
 
-        NumberExpression<Long> monthlyChangeSum =
-                monthlyChange.sum().coalesce(0L).longValue();
+        NumberExpression<Long> monthlyChangeSum = Expressions.numberTemplate(Long.class, "sum({0})", monthlyChange)
+                .coalesce(0L);
 
         List<Tuple> results = queryFactory
                 .select(action, monthlyChangeSum)

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -77,7 +78,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
         NumberExpression<Long> increaseCount = thisMonthNotes.subtract(lastMonthNotes);
 
-        return queryFactory
+        List<ActionChange> results = queryFactory
                 .select(new QActionChange(action, increaseCount.longValue()))
                 .from(note)
                 .join(note.action, action)
@@ -86,8 +87,12 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                         .and(isReceiver(memberId))
                         .and(actionCategory.emotionType.eq(EmotionType.POSITIVE)))
                 .groupBy(action)
-                .orderBy(increaseCount.desc())
-                .fetchFirst();
+                .fetch();
+
+        return results.stream()
+                .sorted(Comparator.comparing(ActionChange::getChange).reversed())
+                .findFirst()
+                .orElse(null);
     }
 
     @Override
@@ -97,7 +102,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         NumberExpression<Long> lastMonthNotes = countLastMonthNotes(today);
         NumberExpression<Long> decreaseCount = thisMonthNotes.subtract(lastMonthNotes);
 
-        return queryFactory
+        List<ActionChange> results = queryFactory
                 .select(new QActionChange(action, decreaseCount.longValue()))
                 .from(note)
                 .join(note.action, action)
@@ -106,8 +111,12 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                         .and(isReceiver(memberId))
                         .and(actionCategory.emotionType.eq(EmotionType.NEGATIVE)))
                 .groupBy(action)
-                .orderBy(decreaseCount.asc())
-                .fetchFirst();
+                .fetch();
+
+        return results.stream()
+                .sorted(Comparator.comparing(ActionChange::getChange))
+                .findFirst()
+                .orElse(null);
     }
 
     @Override

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -201,33 +201,33 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .fetchFirst();
     }
 
-    private NumberExpression<Long> countThisMonthNotes(LocalDate today) {
-        LocalDateTime startOfThisMonth = today.withDayOfMonth(1).atStartOfDay();
-        LocalDateTime endOfThisMonth = today.plusDays(1).atStartOfDay();
+    //    private NumberExpression<Long> countThisMonthNotes(LocalDate today) {
+    //        LocalDateTime startOfThisMonth = today.withDayOfMonth(1).atStartOfDay();
+    //        LocalDateTime endOfThisMonth = today.plusDays(1).atStartOfDay();
+    //
+    //        return new CaseBuilder()
+    //                .when(note.createdAt.goe(startOfThisMonth).and(note.createdAt.lt(endOfThisMonth)))
+    //                .then(1L)
+    //                .otherwise(0L)
+    //                .sum();
+    //    }
 
-        return new CaseBuilder()
-                .when(note.createdAt.goe(startOfThisMonth).and(note.createdAt.lt(endOfThisMonth)))
-                .then(1L)
-                .otherwise(0L)
-                .sum();
-    }
-
-    private NumberExpression<Long> countLastMonthNotes(LocalDate today) {
-        LocalDate lastMonthOfToday = today.minusMonths(1);
-
-        LocalDateTime startOfLastMonth = lastMonthOfToday.withDayOfMonth(1).atStartOfDay();
-        LocalDateTime endOfLastMonth = lastMonthOfToday.plusDays(1).atStartOfDay();
-        if (today.getDayOfMonth() == today.lengthOfMonth()) {
-            endOfLastMonth =
-                    lastMonthOfToday.with(TemporalAdjusters.lastDayOfMonth()).atStartOfDay();
-        }
-
-        return new CaseBuilder()
-                .when(note.createdAt.goe(startOfLastMonth).and(note.createdAt.lt(endOfLastMonth)))
-                .then(1L)
-                .otherwise(0L)
-                .sum();
-    }
+    //    private NumberExpression<Long> countLastMonthNotes(LocalDate today) {
+    //        LocalDate lastMonthOfToday = today.minusMonths(1);
+    //
+    //        LocalDateTime startOfLastMonth = lastMonthOfToday.withDayOfMonth(1).atStartOfDay();
+    //        LocalDateTime endOfLastMonth = lastMonthOfToday.plusDays(1).atStartOfDay();
+    //        if (today.getDayOfMonth() == today.lengthOfMonth()) {
+    //            endOfLastMonth =
+    //                    lastMonthOfToday.with(TemporalAdjusters.lastDayOfMonth()).atStartOfDay();
+    //        }
+    //
+    //        return new CaseBuilder()
+    //                .when(note.createdAt.goe(startOfLastMonth).and(note.createdAt.lt(endOfLastMonth)))
+    //                .then(1L)
+    //                .otherwise(0L)
+    //                .sum();
+    //    }
 
     private NumberExpression<Long> calculateMonthlyChange(LocalDate today) {
         LocalDate firstDayOfThisMonth = today.withDayOfMonth(1);

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -5,6 +5,7 @@ import static com.example.wini.domain.template.domain.QAction.action;
 import static com.example.wini.domain.template.domain.QActionCategory.actionCategory;
 
 import com.example.wini.domain.log.dto.response.ActionChange;
+import com.example.wini.domain.log.dto.response.QActionChange;
 import com.example.wini.domain.log.dto.response.WeeklyNoteCount;
 import com.example.wini.domain.note.domain.Note;
 import com.example.wini.domain.note.domain.SortOrder;
@@ -12,7 +13,6 @@ import com.example.wini.domain.template.domain.ActionCategory;
 import com.example.wini.domain.template.domain.EmotionType;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
@@ -78,7 +78,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         NumberExpression<Long> increaseCount = thisMonthNotes.subtract(lastMonthNotes);
 
         return queryFactory
-                .select(Projections.constructor(ActionChange.class, action, increaseCount))
+                .select(new QActionChange(action, increaseCount))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -98,7 +98,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         NumberExpression<Long> decreaseCount = thisMonthNotes.subtract(lastMonthNotes);
 
         return queryFactory
-                .select(Projections.constructor(ActionChange.class, action, decreaseCount))
+                .select(new QActionChange(action, decreaseCount))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -5,7 +5,6 @@ import static com.example.wini.domain.template.domain.QAction.action;
 import static com.example.wini.domain.template.domain.QActionCategory.actionCategory;
 
 import com.example.wini.domain.log.dto.response.ActionChange;
-import com.example.wini.domain.log.dto.response.QActionChange;
 import com.example.wini.domain.log.dto.response.WeeklyNoteCount;
 import com.example.wini.domain.note.domain.Note;
 import com.example.wini.domain.note.domain.SortOrder;
@@ -13,6 +12,7 @@ import com.example.wini.domain.template.domain.ActionCategory;
 import com.example.wini.domain.template.domain.EmotionType;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
@@ -93,7 +93,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .sum();
 
         List<ActionChange> results = queryFactory
-                .select(new QActionChange(action, increaseCount))
+                .select(Projections.constructor(ActionChange.class, action, increaseCount.as("change")))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -103,9 +103,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .groupBy(action)
                 .fetch();
 
-        return results.stream()
-                .max(Comparator.comparing(ActionChange::getChange))
-                .orElse(null);
+        return results.stream().max(Comparator.comparing(ActionChange::change)).orElse(null);
     }
 
     @Override
@@ -129,19 +127,17 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .sum();
 
         List<ActionChange> results = queryFactory
-                .select(new QActionChange(action, decreaseCount))
+                .select(Projections.constructor(ActionChange.class, action, decreaseCount.as("change")))
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
                 .where(isThisRoom(roomId)
                         .and(isReceiver(memberId))
-                        .and(actionCategory.emotionType.eq(EmotionType.NEGATIVE))) // emotionType을 NEGATIVE로 변경
+                        .and(actionCategory.emotionType.eq(EmotionType.NEGATIVE)))
                 .groupBy(action)
                 .fetch();
 
-        return results.stream()
-                .min(Comparator.comparing(ActionChange::getChange))
-                .orElse(null);
+        return results.stream().min(Comparator.comparing(ActionChange::change)).orElse(null);
     }
 
     @Override

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -80,11 +80,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .then(-1L)
                 .otherwise(0L);
 
-        NumberExpression<Long> monthlyChangeSum = Expressions.numberTemplate(Long.class, "sum({0})", monthlyChange)
-                .coalesce(0L);
-
         List<Tuple> results = queryFactory
-                .select(action, monthlyChangeSum)
+                .select(action, monthlyChange.sum())
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -95,7 +92,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .fetch();
 
         return results.stream()
-                .map(t -> new ActionChange(t.get(action), t.get(monthlyChangeSum)))
+                .map(t -> new ActionChange(t.get(action), t.get(monthlyChange.sum())))
                 .max(Comparator.comparing(ActionChange::monthlyChange))
                 .orElse(null);
     }
@@ -111,11 +108,8 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .then(-1L)
                 .otherwise(0L);
 
-        NumberExpression<Long> monthlyChangeSum = Expressions.numberTemplate(Long.class, "sum({0})", monthlyChange)
-                .coalesce(0L);
-
         List<Tuple> results = queryFactory
-                .select(action, monthlyChangeSum)
+                .select(action, monthlyChange.sum())
                 .from(note)
                 .join(note.action, action)
                 .join(action.actionCategory, actionCategory)
@@ -126,7 +120,7 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
                 .fetch();
 
         return results.stream()
-                .map(t -> new ActionChange(t.get(action), t.get(monthlyChangeSum)))
+                .map(t -> new ActionChange(t.get(action), t.get(monthlyChange.sum())))
                 .min(Comparator.comparing(ActionChange::monthlyChange))
                 .orElse(null);
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #94

## 📌 작업 내용 및 특이사항
- querydsl6으로 업그레이드
- 명시적 캐스팅으로 sum() 집계시 타입 추론 가능하도록 수정
- sum 결과값이 null인 경우 각 필드값에 null 들어가도록 수정

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 없음
- 버그 수정
  - 이번달/지난달 경계 기준을 명확히 적용해 월별 변화 수치가 잘못 표기되던 문제를 수정했습니다.
  - 집계 그룹화 및 최댓값/최솟값 선정 로직을 개선해 누락 사례와 결과 정확성을 향상시켰습니다.
- 리팩터링
  - 월별 변화 계산·집계 로직을 단순화·통합해 일관성과 안정성을 높였습니다.
  - 응답 DTO 필드명이 변경되어 연동 확인이 필요합니다 (change → monthlyChange, 원시 타입→참조 타입).
- 기타(Chores)
  - Querydsl 관련 빌드 의존성 버전을 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->