### PR TITLE
feat: 상태 알림에 상태 텍스트 추가

### DIFF
--- a/src/main/java/com/example/wini/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/wini/domain/member/service/MemberService.java
@@ -93,16 +93,16 @@ public class MemberService {
         Long statusDurationSeconds = request.reservedTimeInfo().toSeconds();
 
         member.updateStatus(status, request.startedAt(), statusDurationSeconds);
-        notifyRoommateOfStatusUpdate(member.getId());
+        notifyRoommateOfStatusUpdate(member.getId(), status.getText());
 
         return MemberStatusResponse.from(member, request.reservedTimeInfo());
     }
 
-    private void notifyRoommateOfStatusUpdate(Long memberId) {
+    private void notifyRoommateOfStatusUpdate(Long memberId, String statusText) {
         Member mate = memberRepository
                 .findRoommateByMemberId(memberId)
                 .orElseThrow(() -> new CustomException(MATE_NOT_FOUND));
-        NotificationEvent event = NotificationEvent.from(mate.getId(), NotificationType.NEW_STATUS);
+        NotificationEvent event = NotificationEvent.from(mate.getId(), NotificationType.NEW_STATUS, statusText);
         eventPublisher.publishEvent(event);
     }
 

--- a/src/main/java/com/example/wini/domain/notification/domain/NotificationType.java
+++ b/src/main/java/com/example/wini/domain/notification/domain/NotificationType.java
@@ -6,13 +6,16 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationType {
-    // TODO: 문구 확정되면 변경하기
     NEW_ROOMMATE("join", "Wini", "룸메이트가 나의 초대에 응했어요.\n이제 함께 Wini를 시작해보세요."),
     NEW_NOTE("note", "Wini", "24시간 내 사라지는 룸메이트의 마음쪽지가 도착했어요."),
-    NEW_STATUS("status", "Wini", "룸메이트가 현재 상태를 변경했어요."),
+    NEW_STATUS("status", "Wini", "룸메이트가 [%s]으로 상태를 변경했어요."),
     ;
 
     private final String type;
     private final String title;
     private final String body;
+
+    public String formatBody(String arg) {
+        return String.format(this.body, arg);
+    }
 }

--- a/src/main/java/com/example/wini/domain/notification/event/NotificationEvent.java
+++ b/src/main/java/com/example/wini/domain/notification/event/NotificationEvent.java
@@ -3,13 +3,18 @@ package com.example.wini.domain.notification.event;
 import com.example.wini.domain.notification.domain.NotificationType;
 import java.util.Optional;
 
-public record NotificationEvent(Long recipientId, NotificationType notificationType, Optional<Long> entityId) {
+public record NotificationEvent(
+        Long recipientId, NotificationType notificationType, Optional<Long> entityId, Optional<String> bodyArg) {
 
     public static NotificationEvent from(Long recipientId, NotificationType notificationType) {
-        return new NotificationEvent(recipientId, notificationType, Optional.empty());
+        return new NotificationEvent(recipientId, notificationType, Optional.empty(), Optional.empty());
     }
 
     public static NotificationEvent from(Long recipientId, NotificationType notificationType, Long id) {
-        return new NotificationEvent(recipientId, notificationType, Optional.of(id));
+        return new NotificationEvent(recipientId, notificationType, Optional.of(id), Optional.empty());
+    }
+
+    public static NotificationEvent from(Long recipientId, NotificationType type, String bodyArg) {
+        return new NotificationEvent(recipientId, type, Optional.empty(), Optional.of(bodyArg));
     }
 }

--- a/src/main/java/com/example/wini/domain/notification/service/FirebaseTokenService.java
+++ b/src/main/java/com/example/wini/domain/notification/service/FirebaseTokenService.java
@@ -22,6 +22,7 @@ public class FirebaseTokenService {
         String token = request.token();
 
         firebaseTokenRepository.deleteByToken(token);
+        firebaseTokenRepository.flush();
 
         FirebaseToken firebaseToken = FirebaseToken.create(member, token);
         firebaseTokenRepository.save(firebaseToken);

--- a/src/main/java/com/example/wini/infra/fcm/client/FcmClient.java
+++ b/src/main/java/com/example/wini/infra/fcm/client/FcmClient.java
@@ -41,8 +41,8 @@ public class FcmClient implements NotificationSender {
     }
 
     private void pushNotification(FirebaseToken firebaseToken, NotificationEvent event) {
-        FcmMessageRequest request =
-                FcmMessageRequest.from(firebaseToken.getToken(), event.notificationType(), event.entityId());
+        FcmMessageRequest request = FcmMessageRequest.from(
+                firebaseToken.getToken(), event.notificationType(), event.bodyArg(), event.entityId());
         Message message = fcmMessageConverter.convert(request);
         try {
             firebaseMessaging.send(message);

--- a/src/main/java/com/example/wini/infra/fcm/dto/FcmMessageRequest.java
+++ b/src/main/java/com/example/wini/infra/fcm/dto/FcmMessageRequest.java
@@ -5,8 +5,11 @@ import java.util.Optional;
 
 public record FcmMessageRequest(String token, String title, String body, String type, Optional<Long> entityId) {
 
-    public static FcmMessageRequest from(String token, NotificationType notificationType, Optional<Long> entityId) {
-        return new FcmMessageRequest(
-                token, notificationType.getTitle(), notificationType.getBody(), notificationType.getType(), entityId);
+    public static FcmMessageRequest from(
+            String token, NotificationType notificationType, Optional<String> arg, Optional<Long> entityId) {
+
+        String body = arg.map(notificationType::formatBody).orElse(notificationType.getBody());
+
+        return new FcmMessageRequest(token, notificationType.getTitle(), body, notificationType.getType(), entityId);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #97 

## 📌 작업 내용 및 특이사항
- 상태 변경 알림 시 어떤 상태로 변경했는지 알 수 있도록 메시지를 변경했습니다. 
- 로그를 확인해보니 fcm 토큰 중복 문제가 간간이 발생해 delete가 제대로 반영되도록 flush()를 추가했습니다. 

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 룸메이트 상태 변경 푸시 알림에 실제 상태 텍스트가 포함됩니다.
  - 알림 본문이 상황에 맞게 동적으로 포매팅됩니다.
- Style
  - 상태 변경 알림 문구를 “룸메이트가 [%s]으로 상태를 변경했어요.”로 업데이트했습니다.
- Chores
  - FCM 토큰 삭제를 즉시 반영하여 알림 전송 신뢰성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->