### PR TITLE
feat: 애플 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,10 @@ dependencies {
     // cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation "com.github.ben-manes.caffeine:caffeine"
+
+    // jwk
+    implementation "com.auth0:jwks-rsa:0.22.1"
+    implementation "com.auth0:java-jwt:4.4.0"
 }
 
 test {

--- a/src/main/java/com/example/wini/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/wini/domain/auth/controller/AuthController.java
@@ -2,10 +2,12 @@ package com.example.wini.domain.auth.controller;
 
 import static com.example.wini.global.common.constant.SecurityConstants.BEARER_TOKEN_PREFIX;
 
+import com.example.wini.domain.auth.dto.request.IdTokenRequest;
 import com.example.wini.domain.auth.dto.response.TokenResponse;
 import com.example.wini.domain.auth.service.AuthService;
 import com.example.wini.domain.auth.service.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
@@ -40,6 +42,12 @@ public class AuthController {
     @Operation(summary = "카카오 로그인 콜백", description = "카카오 로그인 후 토큰을 반환합니다.")
     public TokenResponse kakaoLogin(@RequestParam("code") String authCode) {
         return authService.kakaoLogin(authCode);
+    }
+
+    @PostMapping("/login/apple")
+    @Operation(summary = "애플 로그인", description = "idToken으로 유저 정보 추출 후 토큰을 반환합니다.")
+    public TokenResponse appleLogin(@RequestBody IdTokenRequest request) {
+        return authService.appleLogin(request);
     }
 
     @PostMapping("logout")

--- a/src/main/java/com/example/wini/domain/auth/dto/common/OauthMemberInfo.java
+++ b/src/main/java/com/example/wini/domain/auth/dto/common/OauthMemberInfo.java
@@ -10,4 +10,8 @@ public record OauthMemberInfo(String providerId, String name, String imageUrl) {
                 kakaoUser.kakaoAccount().profile().nickname(),
                 kakaoUser.kakaoAccount().profile().profileImageUrl());
     }
+
+    public static OauthMemberInfo of(String providerId, String name) {
+        return new OauthMemberInfo(providerId, name, null);
+    }
 }

--- a/src/main/java/com/example/wini/domain/auth/dto/request/IdTokenRequest.java
+++ b/src/main/java/com/example/wini/domain/auth/dto/request/IdTokenRequest.java
@@ -1,0 +1,3 @@
+package com.example.wini.domain.auth.dto.request;
+
+public record IdTokenRequest(String idToken) {}

--- a/src/main/java/com/example/wini/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/AuthService.java
@@ -1,13 +1,16 @@
 package com.example.wini.domain.auth.service;
 
+import static com.example.wini.domain.member.domain.OauthProvider.APPLE;
 import static com.example.wini.domain.member.domain.OauthProvider.KAKAO;
 
 import com.example.wini.domain.auth.dto.common.OauthMemberInfo;
+import com.example.wini.domain.auth.dto.request.IdTokenRequest;
 import com.example.wini.domain.auth.dto.response.TokenResponse;
 import com.example.wini.domain.member.domain.Member;
+import com.example.wini.domain.member.domain.OauthProvider;
 import com.example.wini.domain.member.repository.MemberRepository;
+import com.example.wini.infra.apple.service.AppleOauthService;
 import com.example.wini.infra.kakao.client.KakaoClient;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final KakaoClient kakaoClient;
+    private final AppleOauthService appleOauthService;
     private final MemberRepository memberRepository;
     private final TokenService tokenService;
 
@@ -29,14 +33,20 @@ public class AuthService {
     public TokenResponse kakaoLogin(String authCode) {
         String kakaoAccessToken = kakaoClient.getAccessToken(authCode);
         OauthMemberInfo oauthMemberInfo = kakaoClient.getMemberInfo(kakaoAccessToken);
+        return loginOrRegister(oauthMemberInfo, KAKAO);
+    }
 
-        Optional<Member> optionalMember =
-                memberRepository.findByOauthIdAndOauthProvider(oauthMemberInfo.providerId(), KAKAO);
+    @Transactional
+    public TokenResponse appleLogin(IdTokenRequest request) {
+        String idToken = request.idToken();
+        OauthMemberInfo oauthMemberInfo = appleOauthService.parseMemberInfo(idToken);
+        return loginOrRegister(oauthMemberInfo, APPLE);
+    }
 
-        Member member = optionalMember.orElseGet(() -> {
-            Member newMember = Member.create(oauthMemberInfo, KAKAO);
-            return memberRepository.save(newMember);
-        });
+    private TokenResponse loginOrRegister(OauthMemberInfo oauthMemberInfo, OauthProvider provider) {
+        Member member = memberRepository
+                .findByOauthIdAndOauthProvider(oauthMemberInfo.providerId(), provider)
+                .orElseGet(() -> memberRepository.save(Member.create(oauthMemberInfo, provider)));
 
         return tokenService.upsertTokens(member);
     }

--- a/src/main/java/com/example/wini/domain/member/domain/OauthProvider.java
+++ b/src/main/java/com/example/wini/domain/member/domain/OauthProvider.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum OauthProvider {
-    KAKAO("kakao");
+    KAKAO("kakao"),
+    APPLE("apple"),
+    ;
 
     private final String value;
 }

--- a/src/main/java/com/example/wini/global/common/constant/OauthConstants.java
+++ b/src/main/java/com/example/wini/global/common/constant/OauthConstants.java
@@ -3,6 +3,8 @@ package com.example.wini.global.common.constant;
 public class OauthConstants {
 
     public static final String KAKAO_BASE_URL = "https://kauth.kakao.com";
+    public static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/keys";
+    public static final String APPLE_ISSUER_URL = "https://appleid.apple.com";
 
     private OauthConstants() {}
 }

--- a/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
@@ -31,6 +31,8 @@ public enum ErrorCode {
     BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "로그아웃 처리된 토큰입니다."),
     KAKAO_TOKEN_ISSUANCE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 액세스 토큰 발급에 실패했습니다."),
     KAKAO_USERINFO_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 사용자 정보 조회에 실패했습니다."),
+    APPLE_PUBLIC_KEY_NOT_FOUND(HttpStatus.BAD_REQUEST, "일치하는 애플 공개키를 찾을 수 없습니다."),
+    INVALID_ID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 ID 토큰입니다."),
 
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),

--- a/src/main/java/com/example/wini/infra/apple/config/AppleJwkConfig.java
+++ b/src/main/java/com/example/wini/infra/apple/config/AppleJwkConfig.java
@@ -1,0 +1,23 @@
+package com.example.wini.infra.apple.config;
+
+import static com.example.wini.global.common.constant.OauthConstants.APPLE_PUBLIC_KEYS_URL;
+
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.JwkProviderBuilder;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppleJwkConfig {
+
+    @Bean
+    public JwkProvider appleJwkProvider() throws MalformedURLException {
+        return new JwkProviderBuilder(new URL(APPLE_PUBLIC_KEYS_URL))
+                .cached(5, 24, TimeUnit.HOURS) // 24시간 동안 캐싱
+                .rateLimited(10, 1, TimeUnit.MINUTES) // 1분 동안 최대 10번만 요청 (캐시에 값이 없을 경우)
+                .build();
+    }
+}

--- a/src/main/java/com/example/wini/infra/apple/dto/ApplePublicKeyResponse.java
+++ b/src/main/java/com/example/wini/infra/apple/dto/ApplePublicKeyResponse.java
@@ -1,0 +1,17 @@
+package com.example.wini.infra.apple.dto;
+
+import static com.example.wini.global.error.exception.ErrorCode.APPLE_PUBLIC_KEY_NOT_FOUND;
+
+import com.example.wini.global.error.exception.CustomException;
+import java.util.List;
+
+public record ApplePublicKeyResponse(List<Key> keys) {
+    public record Key(String kty, String kid, String use, String alg, String n, String e) {}
+
+    public Key findMatchedPublicKey(String kid, String alg) {
+        return keys.stream()
+                .filter(key -> key.kid().equals(kid) && key.alg().equals(alg))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(APPLE_PUBLIC_KEY_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/wini/infra/apple/service/AppleOauthService.java
+++ b/src/main/java/com/example/wini/infra/apple/service/AppleOauthService.java
@@ -1,0 +1,61 @@
+package com.example.wini.infra.apple.service;
+
+import static com.example.wini.global.common.constant.OauthConstants.APPLE_ISSUER_URL;
+import static com.example.wini.global.error.exception.ErrorCode.INVALID_ID_TOKEN;
+
+import com.auth0.jwk.Jwk;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.example.wini.domain.auth.dto.common.OauthMemberInfo;
+import com.example.wini.global.error.exception.CustomException;
+import java.security.PublicKey;
+import java.security.interfaces.RSAPublicKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AppleOauthService {
+
+    @Value("${apple.client-id}")
+    private String clientId;
+
+    private final JwkProvider appleJwkProvider;
+
+    public OauthMemberInfo parseMemberInfo(String idToken) {
+        DecodedJWT jwt = verifyIdToken(idToken);
+
+        String providerId = jwt.getSubject();
+        String name = jwt.getClaim("name").asString();
+        if (name == null || name.isBlank()) {
+            name = "위니";
+        }
+
+        return OauthMemberInfo.of(providerId, name);
+    }
+
+    private DecodedJWT verifyIdToken(String idToken) {
+        try {
+            DecodedJWT decoded = JWT.decode(idToken);
+            String kid = decoded.getKeyId();
+
+            Jwk jwk = appleJwkProvider.get(kid);
+            PublicKey publicKey = jwk.getPublicKey();
+
+            Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) publicKey, null);
+            JWTVerifier verifier = JWT.require(algorithm)
+                    .withIssuer(APPLE_ISSUER_URL)
+                    .withAudience(clientId)
+                    .build();
+
+            return verifier.verify(idToken);
+
+        } catch (Exception e) {
+            throw new CustomException(INVALID_ID_TOKEN);
+        }
+    }
+}

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -7,3 +7,6 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-key: ${KAKAO_CLIENT_KEY}
   redirect-uri: ${KAKAO_REDIRECT_URI}
+
+apple:
+  client-id: ${APPLE_CLIENT_ID}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,8 @@
 kakao:
   client-id: "test-kakao-client-id"
   redirect-uri: "http://localhost:8080/test/callback"
+apple:
+  client-id: "test-apple-client-id"
 jwt:
   issuer: test-issure
   accessToken:


### PR DESCRIPTION
## 🌱 관련 이슈
- close #99 

## 📌 작업 내용 및 특이사항
- 애플 로그인 구현
- jwks 라이브러리 추가

## 📝 참고사항
- 애플 클라이언트ID 노션에 업데이트 완료

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - Apple 로그인 지원: Apple ID 토큰을 이용해 새로운 로그인 API 엔드포인트에서 계정 생성/로그인 및 토큰 발급이 가능합니다.
  - 인증 오류 응답 개선: 유효하지 않은 토큰 또는 공개키 불일치 상황에서 더 명확한 안내 메시지를 제공합니다.
- 작업
  - 빌드 의존성 업데이트 및 외부 공개키(JWKS) 검증 설정을 추가하여 인증 연동 안정성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->