### PR TITLE
feat: 회원 탈퇴

### DIFF
--- a/src/main/java/com/example/wini/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/wini/domain/member/controller/MemberController.java
@@ -9,10 +9,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Tag(name = "1. 회원 관리", description = "회원 관련 API")
@@ -49,5 +47,12 @@ public class MemberController {
     @Operation(summary = "룸메 정보 조회", description = "룸메 정보를 반환합니다.")
     public MateResponse getMateInfo() {
         return memberService.getMateInfo();
+    }
+
+    @DeleteMapping("/me")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "회원 탈퇴", description = "현재 로그인되어 있는 회원을 탈퇴합니다.")
+    public void withdrawMe() {
+        memberService.withdrawMember();
     }
 }

--- a/src/main/java/com/example/wini/domain/member/domain/Member.java
+++ b/src/main/java/com/example/wini/domain/member/domain/Member.java
@@ -75,4 +75,17 @@ public class Member extends BaseEntity {
         this.statusStartedAt = statusStartedAt;
         this.statusDuration = statusDuration;
     }
+
+    public void deleteData() {
+        this.name = null;
+        this.email = null;
+        this.image = null;
+
+        this.oauthId = null;
+        this.oauthProvider = null;
+
+        this.status = null;
+        this.statusStartedAt = null;
+        this.statusDuration = null;
+    }
 }

--- a/src/main/java/com/example/wini/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/wini/domain/member/service/MemberService.java
@@ -122,4 +122,10 @@ public class MemberService {
 
         return MateResponse.from(query);
     }
+
+    @Transactional(readOnly = false)
+    public void withdrawMember() {
+        Member member = memberUtil.getCurrentMember();
+        memberRepository.delete(member);
+    }
 }

--- a/src/main/java/com/example/wini/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/wini/domain/member/service/MemberService.java
@@ -126,6 +126,6 @@ public class MemberService {
     @Transactional(readOnly = false)
     public void withdrawMember() {
         Member member = memberUtil.getCurrentMember();
-        memberRepository.delete(member);
+        member.deleteData();
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #103

## 📌 작업 내용 및 특이사항
- 회원 탈퇴 API 구현

## 📝 참고사항
- 현재 물리적으로 회원을 삭제하는 방향으로 구현하였으나, 방식을 바꿔 논리적으로 삭제할지 논의 필요

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 로그인된 사용자가 자신의 계정을 삭제(회원 탈퇴, DELETE /me)할 수 있는 엔드포인트 추가. 성공 시 204 No Content 반환.
- **문서**
  - 새 엔드포인트에 대한 API 문서(OpenAPI) 갱신.
- **기능 변경**
  - 탈퇴 시 회원의 개인 정보가 초기화/삭제되어 더 이상 사용자 식별 정보가 보존되지 않음.
- **리팩터**
  - 컨트롤러 임포트 정리 등 코드 가독성 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->