### PR TITLE
feat: 하루 쪽지 개수 제한

### DIFF
--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -1,5 +1,6 @@
 package com.example.wini.domain.note.service;
 
+import static com.example.wini.global.common.constant.NoteConstants.DAILY_NOTE_LIMIT;
 import static com.example.wini.global.error.exception.ErrorCode.*;
 
 import com.example.wini.domain.common.util.MemberUtil;
@@ -117,6 +118,8 @@ public class NoteService {
                 .orElseThrow(() -> new CustomException(CLOSING_NOT_FOUND));
         int nextSequence = getNextSequence();
 
+        checkDailyLimit(nextSequence);
+
         return Note.create(me, mate, room, emotion, action, situation, promise, closing, nextSequence);
     }
 
@@ -137,6 +140,12 @@ public class NoteService {
         Member me = memberUtil.getCurrentMember();
         if (!note.getReceiver().equals(me)) {
             throw new CustomException(NOTE_RECEIVER_MISMATCH);
+        }
+    }
+
+    private void checkDailyLimit(int nextSequence) {
+        if (nextSequence > DAILY_NOTE_LIMIT) {
+            throw new CustomException(NOTE_LIMIT_EXCEEDED);
         }
     }
 }

--- a/src/main/java/com/example/wini/global/common/constant/NoteConstants.java
+++ b/src/main/java/com/example/wini/global/common/constant/NoteConstants.java
@@ -1,0 +1,8 @@
+package com.example.wini.global.common.constant;
+
+public class NoteConstants {
+
+    public static final int DAILY_NOTE_LIMIT = 3;
+
+    private NoteConstants() {}
+}

--- a/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/wini/global/error/exception/ErrorCode.java
@@ -50,6 +50,7 @@ public enum ErrorCode {
     NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 마음쪽지입니다."),
     NOTE_RECEIVER_MISMATCH(HttpStatus.BAD_REQUEST, "마음쪽지의 수신자가 아닙니다."),
     SORT_ORDER_NOT_FOUND(HttpStatus.BAD_REQUEST, "잘못된 정렬 순서입니다."),
+    NOTE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "하루 쪽지 개수 제한을 초과하였습니다."),
 
     // Template
     EMOTION_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "잘못된 감정 분류입니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #96

## 📌 작업 내용 및 특이사항
- 하루 쪽지 개수 3개로 제한

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 하루 쪽지 생성 한도를 도입했습니다. 하루 최대 3개까지 쪽지를 만들 수 있으며, 한도를 초과하면 생성이 차단되고 “하루 쪽지 개수 제한을 초과하였습니다.”라는 안내가 표시됩니다.
  - 한도 내에서는 기존과 동일하게 쪽지를 생성할 수 있으며, 한도를 넘는 시도에 대해 즉시 안내하여 불필요한 작업을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->