### PR TITLE
fix: 나를 대표하는 키워드에서 발생하는 오류

### DIFF
--- a/src/main/java/com/example/wini/domain/template/dto/response/ActionCategoryResponse.java
+++ b/src/main/java/com/example/wini/domain/template/dto/response/ActionCategoryResponse.java
@@ -4,6 +4,9 @@ import com.example.wini.domain.template.domain.ActionCategory;
 
 public record ActionCategoryResponse(Long id, String emotionType, String name) {
     public static ActionCategoryResponse from(ActionCategory category) {
+        if (category == null) {
+            return null;
+        }
         return new ActionCategoryResponse(
                 category.getId(), category.getEmotionType().getValue(), category.getName());
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #109

## 📌 작업 내용 및 특이사항
- 쿼리 반환값이 null인 경우 발생하는 오류 해결
- ActionCategory가 null인 경우 DTO null 반환하도록 수정

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * 특정 상황에서 데이터가 누락(null)된 경우 발생하던 예외로 인해 화면이 중단되던 문제를 수정했습니다. 이제 동일한 상황에서 앱이 안전하게 처리하여 더 이상 충돌하지 않습니다.
  * 항목 정보가 일시적으로 제공되지 않더라도 목록/상세 화면이 정상적으로 동작하도록 안정성을 개선하여 전반적인 사용자 경험을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->