### PR TITLE
feat: 오늘 보낸 쪽지 개수

### DIFF
--- a/src/main/java/com/example/wini/domain/log/dto/response/NoteCountResponse.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/NoteCountResponse.java
@@ -1,0 +1,7 @@
+package com.example.wini.domain.log.dto.response;
+
+public record NoteCountResponse(int count) {
+    public static NoteCountResponse from(int count) {
+        return new NoteCountResponse(count);
+    }
+}

--- a/src/main/java/com/example/wini/domain/note/controller/NoteController.java
+++ b/src/main/java/com/example/wini/domain/note/controller/NoteController.java
@@ -1,6 +1,7 @@
 package com.example.wini.domain.note.controller;
 
 import com.example.wini.domain.common.util.MemberUtil;
+import com.example.wini.domain.log.dto.response.NoteCountResponse;
 import com.example.wini.domain.member.domain.Member;
 import com.example.wini.domain.note.dto.request.NoteCreateRequest;
 import com.example.wini.domain.note.dto.response.NoteResponse;
@@ -42,6 +43,12 @@ public class NoteController {
             @RequestParam(value = "sort", required = false, defaultValue = "latest") String sort) {
         // TODO : 페이징 추가 시 Pageable로 수정
         return noteService.findSavedNotesSorted(sort);
+    }
+
+    @GetMapping("/today/count")
+    @Operation(summary = "오늘 보낸 쪽지 개수 조회", description = "사용자가 오늘 보낸 쪽지 개수를 조회합니다.")
+    public NoteCountResponse countTodayNotes() {
+        return noteService.countTodayNotes();
     }
 
     @PostMapping

--- a/src/main/java/com/example/wini/domain/note/service/NoteService.java
+++ b/src/main/java/com/example/wini/domain/note/service/NoteService.java
@@ -4,6 +4,7 @@ import static com.example.wini.global.common.constant.NoteConstants.DAILY_NOTE_L
 import static com.example.wini.global.error.exception.ErrorCode.*;
 
 import com.example.wini.domain.common.util.MemberUtil;
+import com.example.wini.domain.log.dto.response.NoteCountResponse;
 import com.example.wini.domain.member.domain.Member;
 import com.example.wini.domain.member.repository.MemberRepository;
 import com.example.wini.domain.note.domain.Note;
@@ -78,6 +79,12 @@ public class NoteService {
         return notes.stream().map(SimpleNoteResponse::from).toList();
     }
 
+    @Transactional(readOnly = true)
+    public NoteCountResponse countTodayNotes() {
+        int todayNotes = getNotesSentToday();
+        return NoteCountResponse.from(todayNotes);
+    }
+
     @Transactional(readOnly = false)
     public NoteResponse createNote(NoteCreateRequest request) {
         Member me = memberUtil.getCurrentMember();
@@ -120,19 +127,19 @@ public class NoteService {
         Closing closing = closingRepository
                 .findById(request.closingId())
                 .orElseThrow(() -> new CustomException(CLOSING_NOT_FOUND));
-        int nextSequence = getNextSequence();
+        int nextSequence = getNotesSentToday() + 1;
 
         checkDailyLimit(nextSequence);
 
         return Note.create(me, mate, room, emotion, action, situation, promise, closing, nextSequence);
     }
 
-    private int getNextSequence() {
+    private int getNotesSentToday() {
         Member me = memberUtil.getCurrentMember();
         Room room = roomRepository
                 .findOpenRoomByMemberId(me.getId())
                 .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
-        return noteRepository.countNotesSentToday(me.getId(), room.getId()).intValue() + 1;
+        return noteRepository.countNotesSentToday(me.getId(), room.getId()).intValue();
     }
 
     private void notifyRoommateOfNewNote(Long mateMemberId) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #108

## 📌 작업 내용 및 특이사항
- 사용자가 오늘 보낸 쪽지 개수 조회 API 구현
- 쪽지 개수 응답 DTO 추가

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 오늘 보낸 노트 개수를 조회하는 API 엔드포인트(GET /notes/today/count) 추가. 응답에 count 값을 제공.
- 문서
  - 신규 엔드포인트가 OpenAPI 문서에 반영되어 개발자 포털에서 확인 가능.
- 리팩터링
  - 노트 순번 계산 로직을 정리해 가독성과 유지보수성을 향상(기존 동작에는 영향 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->