### PR TITLE
feat: 이번주 주고받은 감정별 개수

### DIFF
--- a/src/main/java/com/example/wini/domain/log/controller/LogController.java
+++ b/src/main/java/com/example/wini/domain/log/controller/LogController.java
@@ -1,11 +1,13 @@
 package com.example.wini.domain.log.controller;
 
+import com.example.wini.domain.log.dto.response.EmotionCountResponse;
 import com.example.wini.domain.log.dto.response.GrowthResponse;
 import com.example.wini.domain.log.dto.response.KeywordResponse;
 import com.example.wini.domain.log.dto.response.StatisticsResponse;
 import com.example.wini.domain.log.service.LogService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,5 +37,11 @@ public class LogController {
     @Operation(summary = "나의 성장", description = "가장 많이 변화한 액션 횟수와 주차별 받은 긍정 쪽지 개수를 반환합니다.")
     public GrowthResponse getGrowth() {
         return logService.getActionTrendsAndWeeklyPositiveNoteCounts();
+    }
+
+    @GetMapping("/emotion/count")
+    @Operation(summary = "이번주 주고받은 감정별 개수 조회", description = "이번주에 주고받은 쪽지 개수를 감정별로 조회합니다.")
+    public List<EmotionCountResponse> countEmotion() {
+        return logService.countThisWeekEmotion();
     }
 }

--- a/src/main/java/com/example/wini/domain/log/dto/response/EmotionCount.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/EmotionCount.java
@@ -1,0 +1,5 @@
+package com.example.wini.domain.log.dto.response;
+
+import com.example.wini.domain.template.domain.Emotion;
+
+public record EmotionCount(Emotion emotion, Long count) {}

--- a/src/main/java/com/example/wini/domain/log/dto/response/EmotionCountResponse.java
+++ b/src/main/java/com/example/wini/domain/log/dto/response/EmotionCountResponse.java
@@ -1,0 +1,10 @@
+package com.example.wini.domain.log.dto.response;
+
+public record EmotionCountResponse(Long id, Long count) {
+    public static EmotionCountResponse from(EmotionCount emotionCount) {
+        if (emotionCount == null) {
+            return new EmotionCountResponse(null, null);
+        }
+        return new EmotionCountResponse(emotionCount.emotion().getId(), emotionCount.count());
+    }
+}

--- a/src/main/java/com/example/wini/domain/log/service/LogService.java
+++ b/src/main/java/com/example/wini/domain/log/service/LogService.java
@@ -69,4 +69,16 @@ public class LogService {
 
         return GrowthResponse.from(increasedPositiveAction, decreasedNegativeAction, weeklyPositiveNoteCounts);
     }
+
+    @Transactional(readOnly = true)
+    public List<EmotionCountResponse> countThisWeekEmotion() {
+        Member me = memberUtil.getCurrentMember();
+        Room room = roomRepository
+                .findOpenRoomByMemberId(me.getId())
+                .orElseThrow(() -> new CustomException(ROOM_NOT_FOUND));
+
+        List<EmotionCount> thisWeekEmotionCount = noteRepository.countThisWeekNotesByEmotion(me.getId(), room.getId());
+
+        return thisWeekEmotionCount.stream().map(EmotionCountResponse::from).toList();
+    }
 }

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepository.java
@@ -1,6 +1,7 @@
 package com.example.wini.domain.note.repository;
 
 import com.example.wini.domain.log.dto.response.ActionChange;
+import com.example.wini.domain.log.dto.response.EmotionCount;
 import com.example.wini.domain.log.dto.response.WeeklyNoteCount;
 import com.example.wini.domain.note.domain.Note;
 import com.example.wini.domain.note.domain.SortOrder;
@@ -23,6 +24,8 @@ public interface NoteCustomRepository {
     ActionCategory findTopActionCategoryInLast30Days(Long memberId, Long roomId, EmotionType emotionType);
 
     List<WeeklyNoteCount> getWeeklyPositiveNoteCounts(Long memberId, Long roomId);
+
+    List<EmotionCount> countThisWeekNotesByEmotion(Long memberId, Long roomId);
 
     Long countNotesSentToday(Long memberId, Long roomId);
 

--- a/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
+++ b/src/main/java/com/example/wini/domain/note/repository/NoteCustomRepositoryImpl.java
@@ -3,8 +3,10 @@ package com.example.wini.domain.note.repository;
 import static com.example.wini.domain.note.domain.QNote.note;
 import static com.example.wini.domain.template.domain.QAction.action;
 import static com.example.wini.domain.template.domain.QActionCategory.actionCategory;
+import static com.example.wini.domain.template.domain.QEmotion.emotion;
 
 import com.example.wini.domain.log.dto.response.ActionChange;
+import com.example.wini.domain.log.dto.response.EmotionCount;
 import com.example.wini.domain.log.dto.response.WeeklyNoteCount;
 import com.example.wini.domain.note.domain.Note;
 import com.example.wini.domain.note.domain.SortOrder;
@@ -19,10 +21,8 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -173,6 +173,23 @@ public class NoteCustomRepositoryImpl implements NoteCustomRepository {
         }
 
         return results;
+    }
+
+    @Override
+    public List<EmotionCount> countThisWeekNotesByEmotion(Long memberId, Long roomId) {
+        List<Tuple> results = queryFactory
+                .select(note.emotion, note.count())
+                .from(note)
+                .join(note.emotion, emotion)
+                .where(isThisRoom(roomId)
+                        .and(isSender(memberId).or(isReceiver(memberId)))
+                        .and(isCreatedThisWeek()))
+                .groupBy(note.emotion)
+                .fetch();
+
+        return results.stream()
+                .map(t -> new EmotionCount(t.get(note.emotion), t.get(note.count())))
+                .collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
## 🌱 관련 이슈
- close #107

## 📌 작업 내용 및 특이사항
- 이번주 주고받은 감정별 개수 조회 API 구현
- 관련 쿼리 추가

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 주간 감정 통계 API 추가: GET /log/emotion/count
  - 현재 주(서버 기준) 노트를 감정별로 집계해 목록으로 반환합니다.
  - 각 항목은 emotionId와 count를 포함합니다.
  - 사용자가 참여 중인 열린 방 기준으로 집계되며, 송신/수신 노트 모두 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->