### PR TITLE
bug: 애플 로그인 Id토큰 인식 불가

### DIFF
--- a/src/main/java/com/example/wini/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/wini/domain/auth/controller/AuthController.java
@@ -7,7 +7,6 @@ import com.example.wini.domain.auth.dto.response.TokenResponse;
 import com.example.wini.domain.auth.service.AuthService;
 import com.example.wini.domain.auth.service.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
@@ -15,6 +14,7 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -46,6 +46,7 @@ public class AuthController {
     }
 
     @PostMapping("/login/apple")
+    @SecurityRequirements
     @Operation(summary = "애플 로그인", description = "idToken으로 유저 정보 추출 후 토큰을 반환합니다.")
     public TokenResponse appleLogin(@RequestBody IdTokenRequest request) {
         return authService.appleLogin(request);

--- a/src/main/java/com/example/wini/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/AuthService.java
@@ -50,7 +50,7 @@ public class AuthService {
     @Transactional
     public TokenResponse appleLogin(IdTokenRequest request) {
         String idToken = request.idToken();
-        log.info(idToken);
+        log.info("idToken: {}", request.idToken());
         OauthMemberInfo oauthMemberInfo = appleOauthService.parseMemberInfo(idToken);
         return loginOrRegister(oauthMemberInfo, APPLE);
     }

--- a/src/main/java/com/example/wini/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/AuthService.java
@@ -50,7 +50,6 @@ public class AuthService {
     @Transactional
     public TokenResponse appleLogin(IdTokenRequest request) {
         String idToken = request.idToken();
-        log.info("idToken: {}", request.idToken());
         OauthMemberInfo oauthMemberInfo = appleOauthService.parseMemberInfo(idToken);
         return loginOrRegister(oauthMemberInfo, APPLE);
     }

--- a/src/main/java/com/example/wini/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/wini/domain/auth/service/AuthService.java
@@ -14,9 +14,11 @@ import com.example.wini.infra.kakao.client.KakaoClient;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -48,6 +50,7 @@ public class AuthService {
     @Transactional
     public TokenResponse appleLogin(IdTokenRequest request) {
         String idToken = request.idToken();
+        log.info(idToken);
         OauthMemberInfo oauthMemberInfo = appleOauthService.parseMemberInfo(idToken);
         return loginOrRegister(oauthMemberInfo, APPLE);
     }

--- a/src/main/java/com/example/wini/infra/apple/service/AppleOauthService.java
+++ b/src/main/java/com/example/wini/infra/apple/service/AppleOauthService.java
@@ -42,7 +42,6 @@ public class AppleOauthService {
 
     private DecodedJWT verifyIdToken(String idToken) {
         try {
-            log.info(idToken);
             DecodedJWT decoded = JWT.decode(idToken);
             String kid = decoded.getKeyId();
 

--- a/src/main/java/com/example/wini/infra/apple/service/AppleOauthService.java
+++ b/src/main/java/com/example/wini/infra/apple/service/AppleOauthService.java
@@ -14,9 +14,11 @@ import com.example.wini.global.error.exception.CustomException;
 import java.security.PublicKey;
 import java.security.interfaces.RSAPublicKey;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AppleOauthService {
@@ -40,6 +42,7 @@ public class AppleOauthService {
 
     private DecodedJWT verifyIdToken(String idToken) {
         try {
+            log.info(idToken);
             DecodedJWT decoded = JWT.decode(idToken);
             String kid = decoded.getKeyId();
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #118 

## 📌 작업 내용 및 특이사항
- 애플 로그인 토큰 확인을 위한 로그 추가

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 인증 관련 서비스에 운영용 로깅(@Slf4j) 도입으로 모니터링·진단이 개선되었습니다.
  * Apple 로그인 흐름에서 수신된 ID 토큰이 로그로 남을 수 있으며 로그 레벨 정책이 적용됩니다.
  * Apple 연동 엔드포인트에 보안 설정 표기가 명시적으로 추가되었습니다(동작 영향 없음).
  * 기능 동작·예외 처리·성능·사용자 경험에는 변화 없고 별도 설정/마이그레이션 불필요합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->