### PR TITLE
fix: 회원 탈퇴 시 발생하는 오류

### DIFF
--- a/src/main/java/com/example/wini/domain/member/domain/Member.java
+++ b/src/main/java/com/example/wini/domain/member/domain/Member.java
@@ -77,12 +77,14 @@ public class Member extends BaseEntity {
     }
 
     public void deleteData() {
-        this.name = null;
-        this.email = null;
+        String uniqueSuffix = "deleted_" + this.id + "_" + System.currentTimeMillis();
+
+        this.name = "탈퇴회원";
+        this.email = uniqueSuffix + "@deleted.com";
         this.image = null;
 
-        this.oauthId = null;
-        this.oauthProvider = null;
+        this.oauthId = uniqueSuffix;
+        this.oauthProvider = OauthProvider.NONE;
 
         this.status = null;
         this.statusStartedAt = null;

--- a/src/main/java/com/example/wini/domain/member/domain/OauthProvider.java
+++ b/src/main/java/com/example/wini/domain/member/domain/OauthProvider.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum OauthProvider {
     KAKAO("kakao"),
     APPLE("apple"),
+    NONE(""),
     ;
 
     private final String value;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #120

## 📌 작업 내용 및 특이사항
- nullable하지 않은 필드를 null로 설정해서 발생하는 오류 -> nullable하지 않은 필드에 고유한 빈 값 부여하도록 수정
- OauthProvider에 비어있는 enum 추가

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 회원 탈퇴 시 이름을 ‘탈퇴회원’으로 표시하고, 이메일/소셜 ID를 고유 식별자로 대체하여 비식별화합니다. 프로필 이미지는 제거됩니다.
* 버그 수정
  * 소셜 연동 정보가 제거된 계정에서도 예외 없이 안정적으로 동작하도록 처리 로직을 보강했습니다.
  * 탈퇴 후 상태 값이 유지되어 목록 및 알림 등에서 최신 상태가 정확히 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->